### PR TITLE
Expose batch geometry/clean-up operations as headless CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,44 @@ Running NifSkope under Wayland on Linux may require setting the QT\_QPA\_PLATFOR
 
 The resource manager in this version of NifSkope is optimized for PCs with solid-state drives. While hard disk drives generally also work, if the number of loose resources is large, load times can be significantly shorter on an SSD when the data is not cached yet by the operating system.
 
+#### Command-line (headless) usage
+
+NifSkope can be run without a GUI by passing the **-no-gui** flag. In this mode the application performs batch operations and exits, without opening any window.
+
+    NifSkope -no-gui --ConvertToInternalGeometry <path>
+    NifSkope -no-gui --ConvertToExternalGeometry <path>
+    NifSkope -no-gui --ConvertToExternalGeometry <path> -o <folder>
+    NifSkope -no-gui --RemoveUnusedStrings <path>
+    NifSkope -no-gui --RemoveDuplicateVertices <path>
+    NifSkope -no-gui --RemoveUnusedVertices <path>
+    NifSkope -no-gui --GenerateMeshLODs <path>
+    NifSkope -no-gui --OptimizeIndices <path>
+    NifSkope -no-gui --AddTangentSpacesAndUpdate <path>
+    NifSkope -no-gui --UpdateBounds <path>
+    NifSkope -no-gui --CombineProperties <path>
+    NifSkope -no-gui --RemoveBogusNodes <path>
+    NifSkope -no-gui --ReorderBlocks <path>
+    NifSkope -no-gui --SanitizeBeforeSave <path>
+
+Running with **-no-gui** and no further option prints a usage summary and exits with a non-zero code.
+
+| Option | Argument | Description |
+|--------|----------|-------------|
+| `--ConvertToInternalGeometry` | `<path>` | Convert all external `.mesh` geometry in Starfield NIF file(s) to internal geometry. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. Non-Starfield files (BSVersion < 170) and files that already use internal geometry are skipped without modification. |
+| `--ConvertToExternalGeometry` | `<path>` | Convert internal geometry in Starfield NIF file(s) to external `.mesh` files. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. Non-Starfield files (BSVersion < 170) and files that already use external geometry are skipped without modification. Uses `-o` output folder when provided; otherwise falls back to the saved output directory from GUI `Convert to External Geometry` and reports an error if neither is available. |
+| `-o`, `--OutputFolder` | `<folder>` | Optional output folder used by `--ConvertToExternalGeometry` for writing exported `.mesh` files. |
+| `--RemoveUnusedStrings` | `<path>` | Remove any unreferenced strings from the NIF header. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--RemoveDuplicateVertices` | `<path>` | Remove duplicate vertices from all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.). `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. **Warning:** for Starfield NIFs this operation may break any associated morph files; no morph file check is performed. |
+| `--RemoveUnusedVertices` | `<path>` | Remove unused vertices from all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.). `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. **Warning:** for Starfield NIFs this operation may break any associated morph files; no morph file check is performed. |
+| `--GenerateMeshLODs` | `<path>` | Generate Starfield mesh LODs for internal BSGeometry blocks. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. Non-Starfield files (BSVersion < 170) are skipped without modification. |
+| `--OptimizeIndices` | `<path>` | Optimize triangle index ordering for vertex cache efficiency across all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.). `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--AddTangentSpacesAndUpdate` | `<path>` | Add missing tangent space arrays and update tangent/bitangent data where applicable. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--UpdateBounds` | `<path>` | Update bounding spheres/boxes for contained geometry where applicable. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--CombineProperties` | `<path>` | Combine duplicate shader properties (NiProperty, NiSourceTexture, BSShaderTextureSet) into a single shared block. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--RemoveBogusNodes` | `<path>` | Remove useless or incorrect block types for the target NIF version where applicable. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--ReorderBlocks` | `<path>` | Reorder blocks so the game can properly load them. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--SanitizeBeforeSave` | `<path>` | Fix minor errors (for example duplicate block names) before save. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+
 #### Building from source code (Qt 6)
 
 Compiling NifSkope requires Qt 6.4 or newer, or Qt 5.15. On Windows, [MSYS2](https://www.msys2.org/) can be used for building. After running the MSYS2 installer, use the following commands in the MSYS2-UCRT64 shell to install required packages:

--- a/build/README.md.in
+++ b/build/README.md.in
@@ -37,6 +37,44 @@ Running NifSkope under Wayland on Linux may require setting the QT\_QPA\_PLATFOR
 
 The resource manager in this version of NifSkope is optimized for PCs with solid-state drives. While hard disk drives generally also work, if the number of loose resources is large, load times can be significantly shorter on an SSD when the data is not cached yet by the operating system.
 
+#### Command-line (headless) usage
+
+NifSkope can be run without a GUI by passing the **-no-gui** flag. In this mode the application performs batch operations and exits, without opening any window.
+
+    NifSkope -no-gui --ConvertToInternalGeometry <path>
+    NifSkope -no-gui --ConvertToExternalGeometry <path>
+    NifSkope -no-gui --ConvertToExternalGeometry <path> -o <folder>
+    NifSkope -no-gui --RemoveUnusedStrings <path>
+    NifSkope -no-gui --RemoveDuplicateVertices <path>
+    NifSkope -no-gui --RemoveUnusedVertices <path>
+    NifSkope -no-gui --GenerateMeshLODs <path>
+    NifSkope -no-gui --OptimizeIndices <path>
+    NifSkope -no-gui --AddTangentSpacesAndUpdate <path>
+    NifSkope -no-gui --UpdateBounds <path>
+    NifSkope -no-gui --CombineProperties <path>
+    NifSkope -no-gui --RemoveBogusNodes <path>
+    NifSkope -no-gui --ReorderBlocks <path>
+    NifSkope -no-gui --SanitizeBeforeSave <path>
+
+Running with **-no-gui** and no further option prints a usage summary and exits with a non-zero code.
+
+| Option | Argument | Description |
+|--------|----------|-------------|
+| `--ConvertToInternalGeometry` | `<path>` | Convert all external `.mesh` geometry in Starfield NIF file(s) to internal geometry. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. Non-Starfield files (BSVersion < 170) and files that already use internal geometry are skipped without modification. |
+| `--ConvertToExternalGeometry` | `<path>` | Convert internal geometry in Starfield NIF file(s) to external `.mesh` files. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. Non-Starfield files (BSVersion < 170) and files that already use external geometry are skipped without modification. Uses `-o` output folder when provided; otherwise falls back to the saved output directory from GUI `Convert to External Geometry` and reports an error if neither is available. |
+| `-o`, `--OutputFolder` | `<folder>` | Optional output folder used by `--ConvertToExternalGeometry` for writing exported `.mesh` files. |
+| `--RemoveUnusedStrings` | `<path>` | Remove any unreferenced strings from the NIF header. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--RemoveDuplicateVertices` | `<path>` | Remove duplicate vertices from all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.). `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. **Warning:** for Starfield NIFs this operation may break any associated morph files; no morph file check is performed. |
+| `--RemoveUnusedVertices` | `<path>` | Remove unused vertices from all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.). `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. **Warning:** for Starfield NIFs this operation may break any associated morph files; no morph file check is performed. |
+| `--GenerateMeshLODs` | `<path>` | Generate Starfield mesh LODs for internal BSGeometry blocks. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. Non-Starfield files (BSVersion < 170) are skipped without modification. |
+| `--OptimizeIndices` | `<path>` | Optimize triangle index ordering for vertex cache efficiency across all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.). `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--AddTangentSpacesAndUpdate` | `<path>` | Add missing tangent space arrays and update tangent/bitangent data where applicable. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--UpdateBounds` | `<path>` | Update bounding spheres/boxes for contained geometry where applicable. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--CombineProperties` | `<path>` | Combine duplicate shader properties (NiProperty, NiSourceTexture, BSShaderTextureSet) into a single shared block. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--RemoveBogusNodes` | `<path>` | Remove useless or incorrect block types for the target NIF version where applicable. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--ReorderBlocks` | `<path>` | Reorder blocks so the game can properly load them. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+| `--SanitizeBeforeSave` | `<path>` | Fix minor errors (for example duplicate block names) before save. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
+
 #### Building from source code (Qt 6)
 
 Compiling NifSkope requires Qt 6.4 or newer, or Qt 5.15. On Windows, [MSYS2](https://www.msys2.org/) can be used for building. After running the MSYS2 installer, use the following commands in the MSYS2-UCRT64 shell to install required packages:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,9 +41,12 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QCommandLineParser>
 #include <QDesktopServices>
 #include <QDir>
+#include <QDirIterator>
+#include <QFile>
 #include <QSettings>
 #include <QStack>
 #include <QSurfaceFormat>
+#include <QTextStream>
 #include <QUdpSocket>
 #include <QUrl>
 
@@ -68,7 +71,7 @@ QCoreApplication * createApplication( int &argc, char *argv[] )
 	// Iterate over args
 	for ( int i = 1; i < argc; ++i ) {
 		// -no-gui: start as core app without all the GUI overhead
-		if ( !qstrcmp( argv[i], "-no-gui" ) ) {
+		if ( !qstrcmp( argv[i], "-no-gui" ) || !qstrcmp( argv[i], "--no-gui" ) ) {
 			return new QCoreApplication( argc, argv );
 		}
 	}
@@ -135,8 +138,144 @@ int main( int argc, char * argv[] )
 		QCommandLineOption portOption( {"p", "port"}, "Port NifSkope listens on", "port" );
 		parser.addOption( portOption );
 
+		// Headless batch options — require -no-gui; documented here so they appear in --help
+		QCommandLineOption guiConvertToInternalGeomOpt(
+			QStringLiteral( "ConvertToInternalGeometry" ),
+			QStringLiteral( "Headless: convert external .mesh geometry in Starfield NIF file(s) to internal geometry."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiConvertToInternalGeomOpt );
+
+		QCommandLineOption guiConvertToExternalGeomOpt(
+			QStringLiteral( "ConvertToExternalGeometry" ),
+			QStringLiteral( "Headless: convert internal geometry in Starfield NIF file(s) to external .mesh files."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place."
+				" Uses -o when provided, otherwise falls back to saved GUI export output path." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiConvertToExternalGeomOpt );
+
+		QCommandLineOption guiOutputFolderOpt(
+			QStringList{ QStringLiteral( "o" ), QStringLiteral( "OutputFolder" ) },
+			QStringLiteral( "Headless: output folder for --ConvertToExternalGeometry .mesh export files."
+				" Requires -no-gui." ),
+			QStringLiteral( "folder" ) );
+		parser.addOption( guiOutputFolderOpt );
+
+		QCommandLineOption guiRemoveUnusedStringsOpt(
+			QStringLiteral( "RemoveUnusedStrings" ),
+			QStringLiteral( "Headless: remove any unreferenced strings from the NIF header."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiRemoveUnusedStringsOpt );
+
+		QCommandLineOption guiRemoveDuplicateVerticesOpt(
+			QStringLiteral( "RemoveDuplicateVertices" ),
+			QStringLiteral( "Headless: remove duplicate vertices from all geometry blocks."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place."
+				" Warning: for Starfield NIFs this may break any associated morph files." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiRemoveDuplicateVerticesOpt );
+
+		QCommandLineOption guiRemoveUnusedVerticesOpt(
+			QStringLiteral( "RemoveUnusedVertices" ),
+			QStringLiteral( "Headless: remove unused vertices from all geometry blocks."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place."
+				" Warning: for Starfield NIFs this may break any associated morph files." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiRemoveUnusedVerticesOpt );
+
+		QCommandLineOption guiGenerateMeshLODsOpt(
+			QStringLiteral( "GenerateMeshLODs" ),
+			QStringLiteral( "Headless: generate simplified Starfield mesh LODs for internal BSGeometry blocks."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place."
+				" Non-Starfield files are skipped." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiGenerateMeshLODsOpt );
+
+		QCommandLineOption guiOptimizeIndicesOpt(
+			QStringLiteral( "OptimizeIndices" ),
+			QStringLiteral( "Headless: optimize triangle index ordering for vertex cache efficiency across all geometry blocks."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiOptimizeIndicesOpt );
+
+		QCommandLineOption guiAddTangentSpacesAndUpdateOpt(
+			QStringLiteral( "AddTangentSpacesAndUpdate" ),
+			QStringLiteral( "Headless: add missing tangent spaces and update tangent/bitangent data where applicable."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiAddTangentSpacesAndUpdateOpt );
+
+		QCommandLineOption guiUpdateBoundsOpt(
+			QStringLiteral( "UpdateBounds" ),
+			QStringLiteral( "Headless: update bounding spheres/boxes for contained geometry where applicable."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiUpdateBoundsOpt );
+
+		QCommandLineOption guiCombinePropertiesOpt(
+			QStringLiteral( "CombineProperties" ),
+			QStringLiteral( "Headless: combine duplicate shader properties into one shared block."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiCombinePropertiesOpt );
+
+		QCommandLineOption guiRemoveBogusNodesOpt(
+			QStringLiteral( "RemoveBogusNodes" ),
+			QStringLiteral( "Headless: remove useless or incorrect block types for the NIF version where applicable."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiRemoveBogusNodesOpt );
+
+		QCommandLineOption guiReorderBlocksOpt(
+			QStringLiteral( "ReorderBlocks" ),
+			QStringLiteral( "Headless: reorder blocks so the game can properly load them."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiReorderBlocksOpt );
+
+		QCommandLineOption guiSanitizeBeforeSaveOpt(
+			QStringLiteral( "SanitizeBeforeSave" ),
+			QStringLiteral( "Headless: fix minor errors (for example duplicate block names) before save."
+				" Requires -no-gui. Accepts a single .nif file or a folder (recursive). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( guiSanitizeBeforeSaveOpt );
+
 		// Process options
 		parser.process( *a );
+
+		// Headless options are not supported in GUI mode
+		const struct HeadlessGuardOption {
+			const QCommandLineOption * option;
+			const char * errorMessage;
+		} headlessGuardOptions[] = {
+			{ &guiConvertToInternalGeomOpt, "Error: --ConvertToInternalGeometry requires headless mode. Use: NifSkope -no-gui --ConvertToInternalGeometry <path>\n" },
+			{ &guiConvertToExternalGeomOpt, "Error: --ConvertToExternalGeometry requires headless mode. Use: NifSkope -no-gui --ConvertToExternalGeometry <path>\n" },
+			{ &guiOutputFolderOpt, "Error: -o/--OutputFolder requires headless mode. Use: NifSkope -no-gui --ConvertToExternalGeometry <path> -o <folder>\n" },
+			{ &guiRemoveUnusedStringsOpt, "Error: --RemoveUnusedStrings requires headless mode. Use: NifSkope -no-gui --RemoveUnusedStrings <path>\n" },
+			{ &guiRemoveDuplicateVerticesOpt, "Error: --RemoveDuplicateVertices requires headless mode. Use: NifSkope -no-gui --RemoveDuplicateVertices <path>\n" },
+			{ &guiRemoveUnusedVerticesOpt, "Error: --RemoveUnusedVertices requires headless mode. Use: NifSkope -no-gui --RemoveUnusedVertices <path>\n" },
+			{ &guiGenerateMeshLODsOpt, "Error: --GenerateMeshLODs requires headless mode. Use: NifSkope -no-gui --GenerateMeshLODs <path>\n" },
+			{ &guiOptimizeIndicesOpt, "Error: --OptimizeIndices requires headless mode. Use: NifSkope -no-gui --OptimizeIndices <path>\n" },
+			{ &guiAddTangentSpacesAndUpdateOpt, "Error: --AddTangentSpacesAndUpdate requires headless mode. Use: NifSkope -no-gui --AddTangentSpacesAndUpdate <path>\n" },
+			{ &guiUpdateBoundsOpt, "Error: --UpdateBounds requires headless mode. Use: NifSkope -no-gui --UpdateBounds <path>\n" },
+			{ &guiCombinePropertiesOpt, "Error: --CombineProperties requires headless mode. Use: NifSkope -no-gui --CombineProperties <path>\n" },
+			{ &guiRemoveBogusNodesOpt, "Error: --RemoveBogusNodes requires headless mode. Use: NifSkope -no-gui --RemoveBogusNodes <path>\n" },
+			{ &guiReorderBlocksOpt, "Error: --ReorderBlocks requires headless mode. Use: NifSkope -no-gui --ReorderBlocks <path>\n" },
+			{ &guiSanitizeBeforeSaveOpt, "Error: --SanitizeBeforeSave requires headless mode. Use: NifSkope -no-gui --SanitizeBeforeSave <path>\n" }
+		};
+
+		bool hasHeadlessOnlyOption = false;
+		QTextStream err( stderr );
+		for ( const auto & guard : headlessGuardOptions ) {
+			if ( parser.isSet( *guard.option ) ) {
+				err << guard.errorMessage;
+				hasHeadlessOnlyOption = true;
+			}
+		}
+		err.flush();
+		if ( hasHeadlessOnlyOption )
+			return 1;
 
 		// Override port value
 		if ( parser.isSet( portOption ) )
@@ -173,7 +312,534 @@ int main( int argc, char * argv[] )
 			return 0;
 		}
 	} else {
-		// Future command line batch tools here
+		// Headless (no-GUI) mode — command line batch tools
+		QTextStream out( stdout );
+		QTextStream err( stderr );
+
+		QCommandLineParser parser;
+		parser.setSingleDashWordOptionMode( QCommandLineParser::ParseAsLongOptions );
+		parser.setApplicationDescription(
+			QString( "NifSkope %1 — headless batch processing" ).arg( NIFSKOPE_VERSION ) );
+		parser.addHelpOption();
+		parser.addVersionOption();
+
+		QCommandLineOption noGuiOpt(
+			QStringLiteral( "no-gui" ),
+			QStringLiteral( "Run in headless mode without launching the GUI." ) );
+		parser.addOption( noGuiOpt );
+
+		QCommandLineOption convertToInternalGeomOpt(
+			QStringLiteral( "ConvertToInternalGeometry" ),
+			QStringLiteral( "Convert all external .mesh geometry in Starfield NIF file(s) to internal geometry."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( convertToInternalGeomOpt );
+
+		QCommandLineOption convertToExternalGeomOpt(
+			QStringLiteral( "ConvertToExternalGeometry" ),
+			QStringLiteral( "Convert all internal geometry in Starfield NIF file(s) to external .mesh files."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place."
+				" Uses -o when provided, otherwise falls back to saved GUI export output path." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( convertToExternalGeomOpt );
+
+		QCommandLineOption outputFolderOpt(
+			QStringList{ QStringLiteral( "o" ), QStringLiteral( "OutputFolder" ) },
+			QStringLiteral( "Output folder for --ConvertToExternalGeometry mesh export files."
+				" If omitted, saved GUI export output path is used." ),
+			QStringLiteral( "folder" ) );
+		parser.addOption( outputFolderOpt );
+
+		QCommandLineOption removeUnusedStringsOpt(
+			QStringLiteral( "RemoveUnusedStrings" ),
+			QStringLiteral( "Remove any unreferenced strings from the NIF header."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( removeUnusedStringsOpt );
+
+		QCommandLineOption removeDuplicateVerticesOpt(
+			QStringLiteral( "RemoveDuplicateVertices" ),
+			QStringLiteral( "Remove duplicate vertices from all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.)."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place."
+				" Warning: for Starfield NIFs this may break any associated morph files." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( removeDuplicateVerticesOpt );
+
+		QCommandLineOption removeUnusedVerticesOpt(
+			QStringLiteral( "RemoveUnusedVertices" ),
+			QStringLiteral( "Remove unused vertices from all geometry blocks (BSTriShape, BSGeometry, NiTriShape, etc.)."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place."
+				" Warning: for Starfield NIFs this may break any associated morph files." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( removeUnusedVerticesOpt );
+
+		QCommandLineOption generateMeshLODsOpt(
+			QStringLiteral( "GenerateMeshLODs" ),
+			QStringLiteral( "Generate Starfield mesh LODs for internal BSGeometry blocks."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place."
+				" Non-Starfield files (BSVersion < 170) are skipped without modification." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( generateMeshLODsOpt );
+
+		QCommandLineOption optimizeIndicesOpt(
+			QStringLiteral( "OptimizeIndices" ),
+			QStringLiteral( "Optimize triangle index ordering for vertex cache efficiency across all geometry blocks"
+				" (BSTriShape, BSGeometry, NiTriShape, etc.)."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( optimizeIndicesOpt );
+
+		QCommandLineOption addTangentSpacesAndUpdateOpt(
+			QStringLiteral( "AddTangentSpacesAndUpdate" ),
+			QStringLiteral( "Add missing tangent spaces and update tangent/bitangent data where applicable."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( addTangentSpacesAndUpdateOpt );
+
+		QCommandLineOption updateBoundsOpt(
+			QStringLiteral( "UpdateBounds" ),
+			QStringLiteral( "Update bounding spheres/boxes for contained geometry where applicable."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( updateBoundsOpt );
+
+		QCommandLineOption combinePropertiesOpt(
+			QStringLiteral( "CombineProperties" ),
+			QStringLiteral( "Combine duplicate shader properties into a single shared block."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( combinePropertiesOpt );
+
+		QCommandLineOption removeBogusNodesOpt(
+			QStringLiteral( "RemoveBogusNodes" ),
+			QStringLiteral( "Remove useless or incorrect block types for the NIF version where applicable."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( removeBogusNodesOpt );
+
+		QCommandLineOption reorderBlocksOpt(
+			QStringLiteral( "ReorderBlocks" ),
+			QStringLiteral( "Reorder blocks so the game can properly load them."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( reorderBlocksOpt );
+
+		QCommandLineOption sanitizeBeforeSaveOpt(
+			QStringLiteral( "SanitizeBeforeSave" ),
+			QStringLiteral( "Fix minor errors (for example duplicate block names) before save."
+				" Accepts a single .nif file or a folder (processed recursively). Files are overwritten in-place." ),
+			QStringLiteral( "path" ) );
+		parser.addOption( sanitizeBeforeSaveOpt );
+
+		parser.process( *app );
+
+		if ( parser.isSet( outputFolderOpt ) && !parser.isSet( convertToExternalGeomOpt ) ) {
+			err << "-o/--OutputFolder can only be used with --ConvertToExternalGeometry\n";
+			err.flush();
+			return 1;
+		}
+
+		if ( !( parser.isSet( convertToInternalGeomOpt ) || parser.isSet( convertToExternalGeomOpt ) || parser.isSet( removeUnusedStringsOpt ) || parser.isSet( removeDuplicateVerticesOpt ) || parser.isSet( removeUnusedVerticesOpt ) || parser.isSet( generateMeshLODsOpt ) || parser.isSet( optimizeIndicesOpt ) || parser.isSet( addTangentSpacesAndUpdateOpt ) || parser.isSet( updateBoundsOpt ) || parser.isSet( combinePropertiesOpt ) || parser.isSet( removeBogusNodesOpt ) || parser.isSet( reorderBlocksOpt ) || parser.isSet( sanitizeBeforeSaveOpt ) ) ) {
+			err << "NifSkope headless mode: no actionable option specified.\n\n";
+			err << parser.helpText();
+			err.flush();
+			return 1;
+		}
+
+		const QString startupWorkingDir = QDir::currentPath();
+
+		// Load NIF/XML schema (required before any NifModel usage)
+		QDir::setCurrent( qApp->applicationDirPath() );
+		NifModel::loadXML();
+		KfmModel::loadXML();
+
+		// Collect .nif files from the given path (file or directory)
+		auto collectNifFiles = [ &startupWorkingDir ]( const QString & path ) -> QStringList {
+			QStringList files;
+			const QString inputPath = QDir::fromNativeSeparators( path ).trimmed();
+			if ( inputPath.isEmpty() )
+				return files;
+
+			QFileInfo fi( inputPath );
+			if ( fi.isRelative() )
+				fi = QFileInfo( QDir( startupWorkingDir ).filePath( inputPath ) );
+
+			if ( fi.isFile() ) {
+				if ( fi.fileName().endsWith( QLatin1String( ".nif" ), Qt::CaseInsensitive ) )
+					files.append( QDir::fromNativeSeparators( fi.absoluteFilePath() ) );
+			} else if ( fi.isDir() ) {
+				QDirIterator it( fi.absoluteFilePath(), QStringList{ QStringLiteral( "*.nif" ) },
+								QDir::Files | QDir::Readable,
+								QDirIterator::Subdirectories );
+				while ( it.hasNext() )
+					files.append( QDir::fromNativeSeparators( it.next() ) );
+			}
+			return files;
+		};
+
+		if ( parser.isSet( convertToInternalGeomOpt ) ) {
+			const QString inputPath = parser.value( convertToInternalGeomOpt );
+			const QStringList fileList = collectNifFiles( inputPath );
+
+			if ( fileList.isEmpty() ) {
+				err << "ConvertToInternalGeometry: no .nif files found at '" << inputPath << "'\n";
+				err.flush();
+				return 1;
+			}
+
+			int exitCode = 0;
+			for ( const QString & filePath : fileList ) {
+				out << "Processing: " << filePath << "\n";
+				out.flush();
+				try {
+					NifModel nif;
+					nif.setBatchProcessingMode( true );
+					{
+						QFile f( filePath );
+						if ( !f.open( QIODevice::ReadOnly ) ) {
+							err << "  Error: cannot open file for reading\n";
+							err.flush();
+							exitCode = 1;
+							continue;
+						}
+						std::string tmp( filePath.toStdString() );
+						nif.load( f, tmp.c_str() );
+					}
+					if ( !nif.getMessages().isEmpty() ) {
+						err << "  Error: failed to parse NIF data\n";
+						err.flush();
+						exitCode = 1;
+						continue;
+					}
+					bool modified = nif.convertToInternalGeometry();
+					if ( modified ) {
+						QFile f( filePath );
+						if ( !f.open( QIODevice::WriteOnly ) ) {
+							err << "  Error: cannot open file for writing\n";
+							err.flush();
+							exitCode = 1;
+							continue;
+						}
+						nif.save( f );
+						out << "  Saved (geometry converted)\n";
+					} else {
+						out << "  Skipped (already internal or not Starfield)\n";
+					}
+					out.flush();
+				} catch ( std::exception & e ) {
+					err << "  Error: " << e.what() << "\n";
+					err.flush();
+					exitCode = 1;
+				}
+			}
+			return exitCode;
+		}
+
+		if ( parser.isSet( convertToExternalGeomOpt ) ) {
+			const QString inputPath = parser.value( convertToExternalGeomOpt );
+			const QStringList fileList = collectNifFiles( inputPath );
+			QString outputFolder;
+			bool useOutputFolderOverride = false;
+			if ( parser.isSet( outputFolderOpt ) ) {
+				outputFolder = QDir::fromNativeSeparators( parser.value( outputFolderOpt ) ).trimmed();
+				if ( outputFolder.isEmpty() ) {
+					err << "ConvertToExternalGeometry: output folder cannot be empty\n";
+					err.flush();
+					return 1;
+				}
+				QDir outDir( outputFolder );
+				if ( !outDir.exists() && !QDir().mkpath( outputFolder ) ) {
+					err << "ConvertToExternalGeometry: failed to create output folder '" << outputFolder << "'\n";
+					err.flush();
+					return 1;
+				}
+				if ( !QFileInfo( outputFolder ).isDir() ) {
+					err << "ConvertToExternalGeometry: output path is not a directory: '" << outputFolder << "'\n";
+					err.flush();
+					return 1;
+				}
+				useOutputFolderOverride = true;
+			}
+
+			if ( fileList.isEmpty() ) {
+				err << "ConvertToExternalGeometry: no .nif files found at '" << inputPath << "'\n";
+				err.flush();
+				return 1;
+			}
+
+			int exitCode = 0;
+			for ( const QString & filePath : fileList ) {
+				out << "Processing: " << filePath << "\n";
+				out.flush();
+				try {
+					NifModel nif;
+					nif.setBatchProcessingMode( true );
+					{
+						QFile f( filePath );
+						if ( !f.open( QIODevice::ReadOnly ) ) {
+							err << "  Error: cannot open file for reading\n";
+							err.flush();
+							exitCode = 1;
+							continue;
+						}
+						std::string tmp( filePath.toStdString() );
+						nif.load( f, tmp.c_str() );
+					}
+					if ( !nif.getMessages().isEmpty() ) {
+						err << "  Error: failed to parse NIF data\n";
+						err.flush();
+						exitCode = 1;
+						continue;
+					}
+					bool modified = useOutputFolderOverride
+						? nif.convertToExternalGeometry( outputFolder )
+						: nif.convertToExternalGeometry();
+					if ( modified ) {
+						QFile f( filePath );
+						if ( !f.open( QIODevice::WriteOnly ) ) {
+							err << "  Error: cannot open file for writing\n";
+							err.flush();
+							exitCode = 1;
+							continue;
+						}
+						nif.save( f );
+						out << "  Saved (geometry converted)\n";
+					} else {
+						out << "  Skipped (already external or not Starfield)\n";
+					}
+					out.flush();
+				} catch ( std::exception & e ) {
+					err << "  Error: " << e.what() << "\n";
+					if ( !useOutputFolderOverride )
+						err << "  Hint: pass -o <folder> or set the output path in GUI using Mesh -> Convert to External Geometry first.\n";
+					err.flush();
+					exitCode = 1;
+				}
+			}
+			return exitCode;
+		}
+
+		auto runBatchOperation = [ & ](
+			const QString & operationName,
+			const QString & inputPath,
+			const QString & savedMessage,
+			const QString & skippedMessage,
+			bool reportsModificationStatus,
+			auto processCallback ) -> int {
+			const QStringList fileList = collectNifFiles( inputPath );
+
+			if ( fileList.isEmpty() ) {
+				err << operationName << ": no .nif files found at '" << inputPath << "'\n";
+				err.flush();
+				return 1;
+			}
+
+			int exitCode = 0;
+			for ( const QString & filePath : fileList ) {
+				out << "Processing: " << filePath << "\n";
+				out.flush();
+				try {
+					NifModel nif;
+					nif.setBatchProcessingMode( true );
+					{
+						QFile f( filePath );
+						if ( !f.open( QIODevice::ReadOnly ) ) {
+							err << "  Error: cannot open file for reading\n";
+							err.flush();
+							exitCode = 1;
+							continue;
+						}
+						std::string tmp( filePath.toStdString() );
+						nif.load( f, tmp.c_str() );
+					}
+					if ( !nif.getMessages().isEmpty() ) {
+						err << "  Error: failed to parse NIF data\n";
+						err.flush();
+						exitCode = 1;
+						continue;
+					}
+
+					QString skipReason;
+					bool processResult = processCallback( nif, skipReason );
+					if ( reportsModificationStatus && !processResult ) {
+						const QString reason = !skipReason.isEmpty()
+							? skipReason
+							: ( !skippedMessage.isEmpty() ? skippedMessage : QString( "not modified" ) );
+						out << "  Skipped (" << reason << ")\n";
+						out.flush();
+						continue;
+					}
+
+					QFile f( filePath );
+					if ( !f.open( QIODevice::WriteOnly ) ) {
+						err << "  Error: cannot open file for writing\n";
+						err.flush();
+						exitCode = 1;
+						continue;
+					}
+					nif.save( f );
+					out << "  Saved (" << savedMessage << ")\n";
+					out.flush();
+				} catch ( std::exception & e ) {
+					err << "  Error: " << e.what() << "\n";
+					err.flush();
+					exitCode = 1;
+				}
+			}
+			return exitCode;
+		};
+
+		if ( parser.isSet( removeUnusedStringsOpt ) ) {
+			return runBatchOperation(
+				"RemoveUnusedStrings",
+				parser.value( removeUnusedStringsOpt ),
+				"unused strings removed",
+				"no unused strings",
+				true,
+				[]( NifModel & nif, QString & ) {
+					return nif.removeUnusedStrings();
+				} );
+		}
+
+		if ( parser.isSet( removeDuplicateVerticesOpt ) ) {
+			err << "Warning: --RemoveDuplicateVertices may break Starfield NIF files that reference morph files."
+				" No morph file check is performed.\n";
+			err.flush();
+			return runBatchOperation(
+				"RemoveDuplicateVertices",
+				parser.value( removeDuplicateVerticesOpt ),
+				"duplicate vertices removed",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.removeDuplicateVertices();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( removeUnusedVerticesOpt ) ) {
+			err << "Warning: --RemoveUnusedVertices may break Starfield NIF files that reference morph files."
+				" No morph file check is performed.\n";
+			err.flush();
+			return runBatchOperation(
+				"RemoveUnusedVertices",
+				parser.value( removeUnusedVerticesOpt ),
+				"unused vertices removed",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.removeUnusedVertices();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( generateMeshLODsOpt ) ) {
+			return runBatchOperation(
+				"GenerateMeshLODs",
+				parser.value( generateMeshLODsOpt ),
+				"LODs generated",
+				"Starfield only",
+				true,
+				[]( NifModel & nif, QString & skipReason ) {
+					if ( nif.getBSVersion() < 170 ) {
+						skipReason = "Starfield only";
+						return false;
+					}
+					nif.generateMeshLODs();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( optimizeIndicesOpt ) ) {
+			return runBatchOperation(
+				"OptimizeIndices",
+				parser.value( optimizeIndicesOpt ),
+				"indices optimized",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.optimizeIndices();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( addTangentSpacesAndUpdateOpt ) ) {
+			return runBatchOperation(
+				"AddTangentSpacesAndUpdate",
+				parser.value( addTangentSpacesAndUpdateOpt ),
+				"tangent spaces added/updated",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.addTangentSpacesAndUpdate();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( updateBoundsOpt ) ) {
+			return runBatchOperation(
+				"UpdateBounds",
+				parser.value( updateBoundsOpt ),
+				"bounds updated",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.updateBounds();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( combinePropertiesOpt ) ) {
+			return runBatchOperation(
+				"CombineProperties",
+				parser.value( combinePropertiesOpt ),
+				"properties combined",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.combineProperties();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( removeBogusNodesOpt ) ) {
+			return runBatchOperation(
+				"RemoveBogusNodes",
+				parser.value( removeBogusNodesOpt ),
+				"bogus nodes removed",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.removeBogusNodes();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( reorderBlocksOpt ) ) {
+			return runBatchOperation(
+				"ReorderBlocks",
+				parser.value( reorderBlocksOpt ),
+				"blocks reordered",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.reorderBlocks();
+					return true;
+				} );
+		}
+
+		if ( parser.isSet( sanitizeBeforeSaveOpt ) ) {
+			return runBatchOperation(
+				"SanitizeBeforeSave",
+				parser.value( sanitizeBeforeSaveOpt ),
+				"sanitized before save",
+				QString(),
+				false,
+				[]( NifModel & nif, QString & ) {
+					nif.sanitizeBeforeSave();
+					return true;
+				} );
+		}
 	}
 
 	return 0;

--- a/src/model/nifmodel.cpp
+++ b/src/model/nifmodel.cpp
@@ -1847,6 +1847,174 @@ public:
 	static bool processAllItems( NifModel * nif );
 };
 
+class spMeshFileExport
+{
+public:
+	static bool processAllItems( NifModel * nif );
+	static bool processAllItems( NifModel * nif, const QString & outputDirectory );
+};
+
+class spRemoveUnusedStrings
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spRemoveAllDuplicateVertices
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spRemoveAllWasteVertices
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spSimplifySFMesh
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spOptimizeAllIndices
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spAddAllTangentSpaces
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spUpdateAllBounds
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spCombiProps
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spRemoveBogusNodes
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+class spSanitizeBlockOrder
+{
+public:
+	static QModelIndex cast_Static( NifModel * nif, const QModelIndex & index );
+};
+
+bool NifModel::convertToInternalGeometry()
+{
+	if ( getBSVersion() < 170 )
+		return false;
+	return spMeshFileImport::processAllItems( this );
+}
+
+bool NifModel::convertToExternalGeometry()
+{
+	if ( getBSVersion() < 170 )
+		return false;
+	return spMeshFileExport::processAllItems( this );
+}
+
+bool NifModel::convertToExternalGeometry( const QString & outputDirectory )
+{
+	if ( getBSVersion() < 170 )
+		return false;
+	return spMeshFileExport::processAllItems( this, outputDirectory );
+}
+
+bool NifModel::removeUnusedStrings()
+{
+	const QModelIndex headerIdx = getHeaderIndex();
+	const quint32 oldNumStrings = get<quint32>( headerIdx, "Num Strings" );
+	// Call the spell's static accessor with an invalid index (required for full-model operation)
+	spRemoveUnusedStrings::cast_Static( this, QModelIndex() );
+	const quint32 newNumStrings = get<quint32>( headerIdx, "Num Strings" );
+	return ( newNumStrings != oldNumStrings );
+}
+
+bool NifModel::removeDuplicateVertices()
+{
+	// Delegates to the batch spell which iterates all geometry block types (BSTriShape, BSGeometry, etc.)
+	spRemoveAllDuplicateVertices::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::removeUnusedVertices()
+{
+	// Delegates to the batch spell which iterates all geometry block types (BSTriShape, BSGeometry, etc.)
+	spRemoveAllWasteVertices::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::generateMeshLODs()
+{
+	// Delegates to the Starfield mesh simplifier spell which processes all applicable BSGeometry blocks.
+	spSimplifySFMesh::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::optimizeIndices()
+{
+	// Delegates to the batch spell which iterates all geometry block types (BSTriShape, BSGeometry, etc.)
+	spOptimizeAllIndices::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::addTangentSpacesAndUpdate()
+{
+	// Delegates to the existing batch spell used by the GUI "Add Tangent Spaces and Update" operation.
+	spAddAllTangentSpaces::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::updateBounds()
+{
+	// Delegates to the existing batch spell used by the GUI "Update Bounds" operation.
+	spUpdateAllBounds::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::combineProperties()
+{
+	// Delegates to the existing spell used by the GUI "Combine Properties" operation.
+	spCombiProps::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::removeBogusNodes()
+{
+	// Delegates to the existing spell used by the GUI "Remove Bogus Nodes" operation.
+	spRemoveBogusNodes::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::reorderBlocks()
+{
+	// Delegates to the existing spell used by the GUI "Reorder Blocks" operation.
+	spSanitizeBlockOrder::cast_Static( this, QModelIndex() );
+	return true;
+}
+
+bool NifModel::sanitizeBeforeSave()
+{
+	// Delegates to the existing sanitize pipeline used by the GUI "Sanitize before Save" operation.
+	SpellBook::sanitize( this );
+	return true;
+}
+
 bool NifModel::checkInternalGeometry( const QModelIndex & blockIndex )
 {
 	if ( !blockIndex.isValid() ) {
@@ -1862,6 +2030,10 @@ bool NifModel::checkInternalGeometry( const QModelIndex & blockIndex )
 		return true;
 	if ( get<quint32>( blockIndex, "Flags" ) & 0x0200 )
 		return true;
+	// In batch/headless mode interactive dialogs are unavailable, so report
+	// the block as non-convertible instead of prompting.
+	if ( getBatchProcessingMode() )
+		return false;
 	if ( QMessageBox::question( parentWindow, tr( "NifSkope warning" ),
 								tr( "This operation can only be performed on internal geometry. Convert meshes?" ) )
 		!= QMessageBox::Yes ) {

--- a/src/model/nifmodel.h
+++ b/src/model/nifmodel.h
@@ -95,6 +95,34 @@ public:
 	void clear() override final;
 	//! Check if a Starfield model uses internal geometry data, and optionally convert meshes. Returns true on success.
 	bool checkInternalGeometry( const QModelIndex & blockIndex );
+	//! Convert all external .mesh geometry in a Starfield NIF to internal geometry. Returns true if any blocks were modified.
+	bool convertToInternalGeometry();
+	//! Convert all internal geometry in a Starfield NIF to external .mesh files. Returns true if any blocks were modified.
+	bool convertToExternalGeometry();
+	//! Convert all internal geometry in a Starfield NIF to external .mesh files using an explicit output folder.
+	bool convertToExternalGeometry( const QString & outputDirectory );
+	//! Remove any unreferenced strings from the NIF header. Returns true if any strings were removed.
+	bool removeUnusedStrings();
+	//! Remove duplicate vertices from all geometry blocks. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool removeDuplicateVertices();
+	//! Remove unused vertices from all geometry blocks. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool removeUnusedVertices();
+	//! Generate Starfield mesh LODs for internal BSGeometry blocks. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool generateMeshLODs();
+	//! Optimize triangle index ordering for vertex cache efficiency across all geometry blocks. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool optimizeIndices();
+	//! Add missing tangent space arrays and update tangents/bitangents across applicable geometry blocks. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool addTangentSpacesAndUpdate();
+	//! Update bounding spheres/boxes for applicable geometry blocks. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool updateBounds();
+	//! Combine duplicate shader properties into a single shared block. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool combineProperties();
+	//! Remove bogus/unlinked nodes for the target NIF version. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool removeBogusNodes();
+	//! Reorder blocks so the game can properly load them. Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool reorderBlocks();
+	//! Sanitize before save to fix minor errors (for example duplicate block names). Returns true when the batch operation runs; modifications are in-memory only (not auto-saved).
+	bool sanitizeBeforeSave();
 	bool load( QIODevice & device, const char* fileName = nullptr ) override final;
 	bool save( QIODevice & device ) const override final;
 

--- a/src/spells/fileextract.cpp
+++ b/src/spells/fileextract.cpp
@@ -408,6 +408,9 @@ REGISTER_SPELL( spExtractAllMaterials )
 class spMeshFileExport final : public Spell
 {
 public:
+	static constexpr const char * kMissingOutputDirectoryError =
+		"missing output directory for external mesh export; use -o <folder> (CLI) or set it in GUI via Convert to External Geometry first";
+
 	QString name() const override final { return Spell::tr( "Convert to External Geometry" ); }
 	QString page() const override final { return Spell::tr( "Mesh" ); }
 
@@ -423,8 +426,26 @@ public:
 
 	static void saveMeshData( QByteArray & meshBuf, NifModel * nif, const NifItem * meshDataItem );
 	static bool processItem( NifModel * nif, NifItem * item, const std::string & outputDirectory, const QString & meshDir );
+	static bool processAllItems( NifModel * nif );
+	static bool processAllItems( NifModel * nif, const QString & outputDirectory );
+	static bool processAllItems( NifModel * nif, const std::string & outputDirectory, const QString & meshDir );
+	static QString getNormalizedMeshDir();
 	QModelIndex cast( NifModel * nif, const QModelIndex & index ) override final;
 };
+
+QString spMeshFileExport::getNormalizedMeshDir()
+{
+	QSettings	settings;
+	QString	meshDir = settings.value( "Settings/Importex/Mesh Export Dir", QString() ).toString().trimmed().toLower();
+	meshDir.replace( QChar('/'), QChar('\\') );
+	while ( meshDir.endsWith( QChar('\\') ) )
+		meshDir.chop( 1 );
+	while ( meshDir.startsWith( QChar('\\') ) )
+		meshDir.remove( 0, 1 );
+	if ( !meshDir.isEmpty() )
+		meshDir.append( QChar('\\') );
+	return meshDir;
+}
 
 void spMeshFileExport::saveMeshData( QByteArray & meshBuf, NifModel * nif, const NifItem * meshDataItem )
 {
@@ -496,6 +517,64 @@ bool spMeshFileExport::processItem(
 	return haveMeshes;
 }
 
+bool spMeshFileExport::processAllItems( NifModel * nif, const std::string & outputDirectory, const QString & meshDir )
+{
+	bool r = false;
+	for ( int b = 0; b < nif->getBlockCount(); b++ )
+		r = r | processItem( nif, nif->getBlockItem( qint32(b) ), outputDirectory, meshDir );
+	return r;
+}
+
+bool spMeshFileExport::processAllItems( NifModel * nif )
+{
+	if ( !( nif && nif->getBSVersion() >= 170 ) )
+		return false;
+
+	std::string	outputDirectory( spResourceFileExtract::getOutputDirectory( nif ) );
+	if ( outputDirectory.empty() ) {
+		if ( nif->getBatchProcessingMode() ) {
+			throw NifSkopeError( kMissingOutputDirectoryError );
+		}
+		return false;
+	}
+
+	QString	meshDir = getNormalizedMeshDir();
+
+	bool meshesConverted = processAllItems( nif, outputDirectory, meshDir );
+	if ( meshesConverted && !nif->getBatchProcessingMode() )
+		Game::GameManager::close_resources();
+	return meshesConverted;
+}
+
+bool spMeshFileExport::processAllItems( NifModel * nif, const QString & outputDirectory )
+{
+	if ( !( nif && nif->getBSVersion() >= 170 ) )
+		return false;
+
+	QString outputDir = QDir::fromNativeSeparators( outputDirectory ).trimmed();
+	while ( outputDir.endsWith( QChar('/') ) )
+		outputDir.chop( 1 );
+	if ( outputDir.isEmpty() ) {
+		if ( nif->getBatchProcessingMode() )
+			throw NifSkopeError( kMissingOutputDirectoryError );
+		return false;
+	}
+
+	std::string outputDirectoryStd( outputDir.toLocal8Bit().constData() );
+	if ( !outputDirectoryStd.empty() ) {
+		char c = outputDirectoryStd.back();
+		if ( c != '/' && c != '\\' )
+			outputDirectoryStd += '/';
+	}
+
+	QString	meshDir = getNormalizedMeshDir();
+
+	bool meshesConverted = processAllItems( nif, outputDirectoryStd, meshDir );
+	if ( meshesConverted && !nif->getBatchProcessingMode() )
+		Game::GameManager::close_resources();
+	return meshesConverted;
+}
+
 QModelIndex spMeshFileExport::cast( NifModel * nif, const QModelIndex & index )
 {
 	if ( !( nif && nif->getBSVersion() >= 170 ) )
@@ -505,29 +584,17 @@ QModelIndex spMeshFileExport::cast( NifModel * nif, const QModelIndex & index )
 	if ( item && !( item->hasName( "BSGeometry" ) && (nif->get<quint32>(item, "Flags") & 0x0200) != 0 ) )
 		return index;
 
-	std::string	outputDirectory( spResourceFileExtract::getOutputDirectory( nif ) );
-	if ( outputDirectory.empty() )
-		return index;
-
-	QString	meshDir;
-	{
-		QSettings	settings;
-		meshDir = settings.value( "Settings/Importex/Mesh Export Dir", QString() ).toString().trimmed().toLower();
-	}
-	meshDir.replace( QChar('/'), QChar('\\') );
-	while ( meshDir.endsWith( QChar('\\') ) )
-		meshDir.chop( 1 );
-	while ( meshDir.startsWith( QChar('\\') ) )
-		meshDir.remove( 0, 1 );
-	if ( !meshDir.isEmpty() )
-		meshDir.append( QChar('\\') );
-
 	bool	meshesConverted = false;
 	if ( item ) {
+		std::string	outputDirectory( spResourceFileExtract::getOutputDirectory( nif ) );
+		if ( outputDirectory.empty() )
+			return index;
+
+		QString	meshDir = getNormalizedMeshDir();
+
 		meshesConverted = processItem( nif, item, outputDirectory, meshDir );
 	} else {
-		for ( int b = 0; b < nif->getBlockCount(); b++ )
-			meshesConverted |= processItem( nif, nif->getBlockItem( qint32(b) ), outputDirectory, meshDir );
+		meshesConverted = processAllItems( nif );
 	}
 	if ( meshesConverted && !nif->getBatchProcessingMode() )
 		Game::GameManager::close_resources();


### PR DESCRIPTION
This PR adds headless command line support for 13 existing model-processing operations that were previously available through batch UI workflows. The goal is feature parity between GUI batch processing and automation-friendly CLI usage, with support for both single-file and folder-based processing.

This PR introduces the following CLI options:

-ConvertToInternalGeometry
-ConvertToExternalGeometry
-RemoveUnusedStrings
-RemoveDuplicateVertices
-RemoveUnusedVertices
-GenerateMeshLODs
-OptimizeIndices
-AddTangentSpacesAndUpdate
-UpdateBounds
-CombineProperties
-RemoveBogusNodes
-ReorderBlocks
-SanitizeBeforeSave