### PR TITLE
fix UV move being divided by 2

### DIFF
--- a/src/ui/widgets/uvedit.cpp
+++ b/src/ui/widgets/uvedit.cpp
@@ -1695,15 +1695,14 @@ void ScalingDialog::setUniform( bool status )
 	}
 }
 
-// 1 unit corresponds to 2 grid squares
 float ScalingDialog::getXMove()
 {
-	return spinXMove->value() / 2.0;
+	return spinXMove->value();
 }
 
 float ScalingDialog::getYMove()
 {
-	return spinYMove->value() / 2.0;
+	return spinYMove->value();
 }
 
 //! A class to perform rotation of UV coordinates


### PR DESCRIPTION
I'm not sure when or how this broke, but the scaling dialog was dividing move values by 2, which was incorrect.