### PR TITLE
fix tga and bmp textures not rendering

### DIFF
--- a/src/gl/gltexloaders.cpp
+++ b/src/gl/gltexloaders.cpp
@@ -170,7 +170,7 @@ static int generateMipMaps( int m )
 			src += yo;
 		}
 
-		glTexImage2D( GL_TEXTURE_2D, m++, 4, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.data() );
+		glTexImage2D( GL_TEXTURE_2D, m++, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.data() );
 	}
 
 	return m;
@@ -324,7 +324,7 @@ static int texLoadRaw( QIODevice & f, int width, int height, int num_mipmaps, in
 
 		convertToRGBA( data1, w, h, bytespp, mask, flipV, flipH, data2 );
 
-		glTexImage2D( GL_TEXTURE_2D, m++, 4, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data2 );
+		glTexImage2D( GL_TEXTURE_2D, m++, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data2 );
 
 		if ( w == 1 && h == 1 )
 			break;
@@ -388,7 +388,7 @@ static int texLoadPal( QIODevice & f, int width, int height, int num_mipmaps, in
 			}
 		}
 
-		glTexImage2D( GL_TEXTURE_2D, m++, 4, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixl );
+		glTexImage2D( GL_TEXTURE_2D, m++, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixl );
 
 		if ( w == 1 && h == 1 )
 			break;
@@ -525,7 +525,7 @@ static GLuint texLoadTGA(
 		if ( depth == 32 ) {
 			texformat.imageEncoding |= TexCache::TexFmt::TEXFMT_RGBA8;
 
-			if ( hdr[2] == TGA_GREY_RLE )
+			if ( hdr[2] == TGA_COLOR_RLE )
 				texformat.imageEncoding |= TexCache::TexFmt::TEXFMT_RLE;
 
 			return texLoadRaw( f, width, height, 1, 32, 4, TGA_RGBA_MASK, flipV, flipH, hdr[2] == TGA_COLOR_RLE );

--- a/src/spells/texture.cpp
+++ b/src/spells/texture.cpp
@@ -161,7 +161,12 @@ QModelIndex getUV( const NifModel * nif, const QModelIndex & index )
 
 static bool texturePathFilterFunc( [[maybe_unused]] void *p, const std::string_view & s )
 {
-	return ( s.starts_with( "textures/" ) && s.ends_with( ".dds" ) );
+    return ( s.starts_with( "textures/" ) && s.ends_with( ".dds" ));
+}
+
+static bool texturePathFilterFuncAlt( [[maybe_unused]] void *p, const std::string_view & s )
+{
+    return ( s.starts_with( "textures/" ) && (s.ends_with( ".dds" ) || s.ends_with( ".tga" ) || s.ends_with( ".png" ) || s.ends_with( ".bmp" )) );
 }
 
 //! Selects a texture filename
@@ -255,7 +260,11 @@ public:
 		}
 
 		std::set< std::string_view >	texturePaths;
-		nif->listResourceFiles( texturePaths, &texturePathFilterFunc );
+        if ( !settings.value( "Settings/Resources/Alternate Extensions" ).toBool() ) {
+            nif->listResourceFiles( texturePaths, &texturePathFilterFunc );
+        } else {
+            nif->listResourceFiles( texturePaths, &texturePathFilterFuncAlt );
+        }
 		std::string	prvPath( file.toStdString() );
 		FileBrowserWidget	fileBrowser( 640, 600, "Choose Texture", texturePaths, prvPath,
 											&( nif->getGameResources() ) );


### PR DESCRIPTION
The calls to [glTexImage2D](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml) specify an invalid internal format (I think). I've changed those to specify GL_RGBA instead. This fixes the bugged tga rendering. I'm not sure how this seemed to work back in dev7.

I also fixed an incorrect header field read, and updated the texture select spell to not filter out alternate file extensions, if the appropriate setting is enabled.