### PR TITLE
add color wheel functionality to vector3 where it is used for color data

### DIFF
--- a/src/data/nifitem.cpp
+++ b/src/data/nifitem.cpp
@@ -32,6 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "nifitem.h"
 #include "model/basemodel.h"
+#include "model/nifmodel.h"
 
 #include <new>
 
@@ -55,6 +56,31 @@ bool NifItem::isDescendantOf( const NifItem * testAncestor ) const
 		} while ( ancestor );
 	}
 
+	return false;
+}
+
+bool NifItem::isVector3Color() const
+{
+	if ( this->isVector3() && this->hasName( "Value" ) ) {
+		NifModel * nif = qobject_cast<NifModel *>( this->parentModel );
+		QModelIndex parent = nif->getBlockIndex( nif->getParent( nif->getBlockIndex( this ) ) );
+		QModelIndex grandparent = nif->getBlockIndex( nif->getParent( parent ) );
+		if ( nif->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) ) {
+			return true;
+		} else if ( nif->isNiBlock( grandparent , "NiControllerSequence" ) ) {
+			QModelIndex iCtrlBlcks = nif->getIndex( grandparent, "Controlled Blocks");
+			for ( int r = 0; r < nif->rowCount( iCtrlBlcks ); r++ ) {
+				QModelIndex iCB = nif->getIndex( iCtrlBlcks, r );
+				QModelIndex iInterp = nif->getBlockIndex( nif->getLink( iCB, "Interpolator" ), "NiInterpolator" );
+				if ( parent == iInterp ) {
+					QModelIndex iController = nif->getBlockIndex( nif->getLink( iCB, "Controller" ), "NiTimeController" );
+					if ( nif->isNiBlock( iController, "BSEffectShaderPropertyColorController") ) {
+						return true;
+					}
+				}
+			}
+		}
+	}
 	return false;
 }
 

--- a/src/data/nifitem.cpp
+++ b/src/data/nifitem.cpp
@@ -65,7 +65,8 @@ bool NifItem::isVector3Color() const
 		NifModel * nif = qobject_cast<NifModel *>( this->parentModel );
 		QModelIndex parent = nif->getBlockIndex( nif->getParent( nif->getBlockIndex( this ) ) );
 		QModelIndex grandparent = nif->getBlockIndex( nif->getParent( parent ) );
-		if ( nif->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) ) {
+		if ( nif->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) ||
+			 nif->isNiBlock( grandparent , "BSEffectShaderPropertyColorController" ) ) {
 			return true;
 		} else if ( nif->isNiBlock( grandparent , "NiControllerSequence" ) ) {
 			QModelIndex iCtrlBlcks = nif->getIndex( grandparent, "Controlled Blocks");
@@ -74,7 +75,8 @@ bool NifItem::isVector3Color() const
 				QModelIndex iInterp = nif->getBlockIndex( nif->getLink( iCB, "Interpolator" ), "NiInterpolator" );
 				if ( parent == iInterp ) {
 					QModelIndex iController = nif->getBlockIndex( nif->getLink( iCB, "Controller" ), "NiTimeController" );
-					if ( nif->isNiBlock( iController, "BSEffectShaderPropertyColorController") ) {
+					if ( nif->isNiBlock( iController, "BSLightingShaderPropertyColorController") ||
+						 nif->isNiBlock( iController, "BSEffectShaderPropertyColorController")) {
 						return true;
 					}
 				}

--- a/src/data/nifitem.h
+++ b/src/data/nifitem.h
@@ -672,17 +672,19 @@ public:
 	inline bool isQuat() const { return itemData.isQuat(); }
 	//! Check if the type of the item's value is a string type.
 	inline bool isString() const { return itemData.isString(); }
-	//! Check if the type of the item's value is a Vector 2.
+	//! Check if the type of the item's value is a Vector2.
 	inline bool isVector2() const { return itemData.isVector2(); }
 	//! Check if the type of the item's value is a HalfVector2.
 	inline bool isHalfVector2() const { return itemData.isHalfVector2(); }
-	//! Check if the type of the item's value is a Vector 3.
+	//! Check if the type of the item's value is a Vector3.
 	inline bool isVector3() const { return itemData.isVector3(); }
+	//! Check if the type of the item's value is a Vector3 used as a color.
+	bool isVector3Color() const;
 	//! Check if the type of the item's value is a Half Vector3.
 	inline bool isHalfVector3() const { return itemData.isHalfVector3(); }
 	//! Check if the type of the item's value is a Byte Vector3.
 	inline bool isByteVector3() const { return itemData.isByteVector3(); }
-	//! Check if the type of the item's value is a Vector 4.
+	//! Check if the type of the item's value is a Vector4.
 	inline bool isVector4() const { return itemData.isVector4(); }
 	//! Check if the type of the item's value is a triangle type.
 	inline bool isTriangle() const { return itemData.isTriangle(); }

--- a/src/data/niftypes.h
+++ b/src/data/niftypes.h
@@ -1435,8 +1435,14 @@ public:
 		rgb[1] = c.greenF();
 		rgb[2] = c.blueF();
 	}
+	
+	//! Convert to Vector3
+	Vector3 toVector3() const
+	{
+		return Vector3( clamp01( rgb[0] ), clamp01( rgb[1] ), clamp01( rgb[2] ) );
+	}
 
-	//! Set from vector
+	//! Set from Vector3
 	void fromVector3( const Vector3 & v )
 	{
 		rgb[0] = v[0];

--- a/src/data/nifvalue.cpp
+++ b/src/data/nifvalue.cpp
@@ -1056,6 +1056,7 @@ QColor NifValue::toColor( const BaseModel * model, const NifItem * item ) const
 {
 	switch ( type() ) {
 	case tColor3:
+	case tVector3:
 		return Color3( val.f32v4[0], val.f32v4[1], val.f32v4[2] ).toQColor();
 	case tColor4:
 	case tByteColor4:

--- a/src/model/nifdelegate.cpp
+++ b/src/model/nifdelegate.cpp
@@ -47,6 +47,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QListView>
 #include <QMessageBox>
 
+const QString SPACE_QSTRING(" ");
 
 //! @file nifdelegate.cpp NifDelegate
 
@@ -196,14 +197,20 @@ public:
 
 		// Color the field background if the value type is a color
 		//	Otherwise normal behavior
-		QVariant color = index.data( Qt::BackgroundRole );
-		if ( color.canConvert<QColor>() )
-			painter->fillRect( option.rect, color.value<QColor>() );
+		QVariant bgcolor = index.data( Qt::BackgroundRole );
+		if ( bgcolor.canConvert<QColor>() )
+			painter->fillRect( option.rect, bgcolor.value<QColor>().rgb() );
 		else if ( option.state & QStyle::State_Selected )
 			painter->fillRect( option.rect, option.palette.brush( cg, QPalette::Highlight ) );
 
 		painter->save();
-		painter->setPen( opt.palette.color( cg, opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::Text ) );
+		
+		QVariant fgcolor = index.data( Qt::ForegroundRole );
+		if ( fgcolor.canConvert<QColor>() )
+			painter->setPen( fgcolor.value<QColor>() );
+		else
+			painter->setPen( opt.palette.color( cg, opt.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::Text ) );
+		
 		painter->setFont( opt.font );
 
 		if ( !icon.isNull() )
@@ -212,8 +219,8 @@ public:
 			painter->drawText( dRect, opt.decorationAlignment, deco );
 
 		if ( !text.isEmpty() ) {
-			drawDisplay( painter, opt, tRect, text );
-			drawFocus( painter, opt, tRect );
+			//drawDisplay( painter, opt, tRect, text );
+			painter->drawText( tRect, Qt::ElideRight | Qt::AlignVCenter, SPACE_QSTRING + text);
 		}
 
 		painter->restore();

--- a/src/model/nifmodel.cpp
+++ b/src/model/nifmodel.cpp
@@ -1567,8 +1567,28 @@ QVariant NifModel::data( const QModelIndex & index, int role ) const
 
 				if ( t[0] >= nvc || t[1] >= nvc || t[2] >= nvc )
 					return QColor::fromRgb( 240, 210, 210 );
-			} else if ( column == ValueCol && item->isColor() ) {
-				return item->getColorValue();
+			} else if ( column == ValueCol ) {
+				if ( item->isColor() ) {
+					return item->getColorValue();
+				} else if ( item->isVector3() ) {
+					QModelIndex parent = this->getBlockIndex( this->getParent( this->getBlockIndex( index ) ) );
+					QModelIndex grandparent = this->getBlockIndex( this->getParent( parent ) );
+					if ( this->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) ) {
+						return item->getColorValue();
+					} else if ( this->isNiBlock( grandparent , "NiControllerSequence" ) ) {
+						QModelIndex iCtrlBlcks = this->getIndex( grandparent, "Controlled Blocks");
+						for ( int r = 0; r < this->rowCount( iCtrlBlcks ); r++ ) {
+							QModelIndex iCB = this->getIndex( iCtrlBlcks, r );
+							QModelIndex iInterp = this->getBlockIndex( this->getLink( iCB, "Interpolator" ), "NiInterpolator" );
+							if ( parent == iInterp ) {
+								QModelIndex iController = this->getBlockIndex( this->getLink( iCB, "Controller" ), "NiTimeController" );
+								if ( this->isNiBlock( iController, "BSEffectShaderPropertyColorController") ) {
+									return item->getColorValue();
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 		return QVariant();

--- a/src/model/nifmodel.cpp
+++ b/src/model/nifmodel.cpp
@@ -1217,7 +1217,6 @@ void NifModel::insertType( NifItem * parent, const NifData & data, int at )
 	restoreState();
 }
 
-
 /*
  *  QAbstractModel interface
  */
@@ -1568,27 +1567,8 @@ QVariant NifModel::data( const QModelIndex & index, int role ) const
 				if ( t[0] >= nvc || t[1] >= nvc || t[2] >= nvc )
 					return QColor::fromRgb( 240, 210, 210 );
 			} else if ( column == ValueCol ) {
-				if ( item->isColor() ) {
+				if ( item->isColor() || item->isVector3Color() )
 					return item->getColorValue();
-				} else if ( item->isVector3() ) {
-					QModelIndex parent = this->getBlockIndex( this->getParent( this->getBlockIndex( index ) ) );
-					QModelIndex grandparent = this->getBlockIndex( this->getParent( parent ) );
-					if ( this->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) ) {
-						return item->getColorValue();
-					} else if ( this->isNiBlock( grandparent , "NiControllerSequence" ) ) {
-						QModelIndex iCtrlBlcks = this->getIndex( grandparent, "Controlled Blocks");
-						for ( int r = 0; r < this->rowCount( iCtrlBlcks ); r++ ) {
-							QModelIndex iCB = this->getIndex( iCtrlBlcks, r );
-							QModelIndex iInterp = this->getBlockIndex( this->getLink( iCB, "Interpolator" ), "NiInterpolator" );
-							if ( parent == iInterp ) {
-								QModelIndex iController = this->getBlockIndex( this->getLink( iCB, "Controller" ), "NiTimeController" );
-								if ( this->isNiBlock( iController, "BSEffectShaderPropertyColorController") ) {
-									return item->getColorValue();
-								}
-							}
-						}
-					}
-				}
 			}
 		}
 		return QVariant();

--- a/src/model/nifmodel.cpp
+++ b/src/model/nifmodel.cpp
@@ -1572,6 +1572,21 @@ QVariant NifModel::data( const QModelIndex & index, int role ) const
 			}
 		}
 		return QVariant();
+	case Qt::ForegroundRole:
+		{
+			if ( column == ValueCol ) {
+				if ( item->isColor() || item->isVector3Color() )
+				{
+					QColor color = item->getColorValue();
+					// this seems better than value or lightness
+					if ( ( color.red() + color.green() + color.blue() ) / 3 > 127 )
+						return QColor( Qt::black );
+					else
+						return QColor( Qt::white );
+				}
+			}
+		}
+		return QVariant();
 	case Qt::UserRole:
 		{
 			if ( column == ValueCol ) {

--- a/src/spells/color.cpp
+++ b/src/spells/color.cpp
@@ -21,8 +21,8 @@ public:
 
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
-		if ( nif->getBlockItem( index ) )
-		if ( nif->getValue( index ).isColor() || ( nif->getItem( index ) && nif->getItem( index )->isVector3Color() ) )
+		if ( nif->getBlockItem( index ) &&
+			( nif->getValue( index ).isColor() || ( nif->getItem( index ) && nif->getItem( index )->isVector3Color() ) ) )
 			return true;
 		return false;
 	}

--- a/src/spells/color.cpp
+++ b/src/spells/color.cpp
@@ -21,27 +21,9 @@ public:
 
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
-		if ( nif->getValue( index ).isColor() )
+		if ( nif->getBlockItem( index ) )
+		if ( nif->getValue( index ).isColor() || ( nif->getItem( index ) && nif->getItem( index )->isVector3Color() ) )
 			return true;
-		else if ( nif->getValue( index ).isVector3() ) {
-			QModelIndex parent = nif->getBlockIndex( nif->getParent( nif->getBlockIndex( index ) ) );
-			QModelIndex grandparent = nif->getBlockIndex( nif->getParent( parent ) );
-			if ( nif->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) )
-				return true;
-			else if ( nif->isNiBlock( grandparent , "NiControllerSequence" ) ) {
-				QModelIndex iCtrlBlcks = nif->getIndex( grandparent, "Controlled Blocks");
-				for ( int r = 0; r < nif->rowCount( iCtrlBlcks ); r++ ) {
-					QModelIndex iCB = nif->getIndex( iCtrlBlcks, r );
-					QModelIndex iInterp = nif->getBlockIndex( nif->getLink( iCB, "Interpolator" ), "NiInterpolator" );
-					if ( parent == iInterp ) {
-						QModelIndex iController = nif->getBlockIndex( nif->getLink( iCB, "Controller" ), "NiTimeController" );
-						if ( nif->isNiBlock( iController, "BSEffectShaderPropertyColorController") ) {
-							return true;
-						}
-					}
-				}
-			}
-		}
 		return false;
 	}
 
@@ -58,6 +40,9 @@ public:
 		} else if ( typ == NifValue::tByteColor4BGRA ) {
 			auto col = ColorWheel::choose( nif->get<ByteColor4BGRA>( index ) );
 			nif->set<ByteColor4BGRA>( index, *static_cast<ByteColor4BGRA *>(&col) );
+		} else if ( typ == NifValue::tVector3 ) {
+			auto col = ColorWheel::choose( nif->get<Vector3>( index ) );
+			nif->set<Vector3>( index, *static_cast<Vector3 *>(&col) );
 		}
 
 		return index;

--- a/src/spells/color.cpp
+++ b/src/spells/color.cpp
@@ -21,7 +21,28 @@ public:
 
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
-		return nif->getValue( index ).isColor();
+		if ( nif->getValue( index ).isColor() )
+			return true;
+		else if ( nif->getValue( index ).isVector3() ) {
+			QModelIndex parent = nif->getBlockIndex( nif->getParent( nif->getBlockIndex( index ) ) );
+			QModelIndex grandparent = nif->getBlockIndex( nif->getParent( parent ) );
+			if ( nif->isNiBlock( grandparent , "BSLightingShaderPropertyColorController" ) )
+				return true;
+			else if ( nif->isNiBlock( grandparent , "NiControllerSequence" ) ) {
+				QModelIndex iCtrlBlcks = nif->getIndex( grandparent, "Controlled Blocks");
+				for ( int r = 0; r < nif->rowCount( iCtrlBlcks ); r++ ) {
+					QModelIndex iCB = nif->getIndex( iCtrlBlcks, r );
+					QModelIndex iInterp = nif->getBlockIndex( nif->getLink( iCB, "Interpolator" ), "NiInterpolator" );
+					if ( parent == iInterp ) {
+						QModelIndex iController = nif->getBlockIndex( nif->getLink( iCB, "Controller" ), "NiTimeController" );
+						if ( nif->isNiBlock( iController, "BSEffectShaderPropertyColorController") ) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
 	}
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & index ) override final
@@ -38,7 +59,6 @@ public:
 			auto col = ColorWheel::choose( nif->get<ByteColor4BGRA>( index ) );
 			nif->set<ByteColor4BGRA>( index, *static_cast<ByteColor4BGRA *>(&col) );
 		}
-
 
 		return index;
 	}

--- a/src/ui/widgets/colorwheel.cpp
+++ b/src/ui/widgets/colorwheel.cpp
@@ -374,6 +374,14 @@ Color4 ColorWheel::choose( const Color4 & c, QWidget * parent )
 	return Color4( choose( c.toQColor(), true, parent ) );
 }
 
+Color3 ColorWheel::choose( const Vector3 & v, QWidget * parent )
+{
+	if ( v.data()[0] > 1.0 || v.data()[1] > 1.0 || v.data()[2] > 1.0 )
+		return Color3( v );
+	
+	return Color3( choose( Color3( v ).toQColor(), false, parent ) );
+}
+
 void ColorWheel::chooseHex()
 {
 	QDialog * dlg = new QDialog();

--- a/src/ui/widgets/colorwheel.cpp
+++ b/src/ui/widgets/colorwheel.cpp
@@ -374,12 +374,12 @@ Color4 ColorWheel::choose( const Color4 & c, QWidget * parent )
 	return Color4( choose( c.toQColor(), true, parent ) );
 }
 
-Color3 ColorWheel::choose( const Vector3 & v, QWidget * parent )
+Vector3 ColorWheel::choose( const Vector3 & v, QWidget * parent )
 {
 	if ( v.data()[0] > 1.0 || v.data()[1] > 1.0 || v.data()[2] > 1.0 )
-		return Color3( v );
+		return Vector3( v );
 	
-	return Color3( choose( Color3( v ).toQColor(), false, parent ) );
+	return Vector3( Color3( choose( Color3( v ).toQColor(), false, parent ) ).toVector3() );
 }
 
 void ColorWheel::chooseHex()

--- a/src/ui/widgets/colorwheel.h
+++ b/src/ui/widgets/colorwheel.h
@@ -57,7 +57,7 @@ public:
 	static QColor choose( const QColor & color, bool alpha = true, QWidget * parent = nullptr );
 	static Color3 choose( const Color3 & color, QWidget * parent = nullptr );
 	static Color4 choose( const Color4 & color, QWidget * parent = nullptr );
-	static Color3 choose( const Vector3 & color, QWidget * parent = nullptr );
+	static Vector3 choose( const Vector3 & color, QWidget * parent = nullptr );
 
 	ColorWheel( QWidget * parent = nullptr );
 	ColorWheel( const QColor & c, QWidget * parent = nullptr );

--- a/src/ui/widgets/colorwheel.h
+++ b/src/ui/widgets/colorwheel.h
@@ -37,6 +37,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QSpinBox>  // Inherited
 
 #include <QColor>
+#include <QVector>
 #include <QRegularExpression>
 #include <QSlider>
 
@@ -45,6 +46,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Color3;
 class Color4;
+class Vector3;
 
 //! A color selection widget using the HSV model
 class ColorWheel final : public QWidget
@@ -55,6 +57,7 @@ public:
 	static QColor choose( const QColor & color, bool alpha = true, QWidget * parent = nullptr );
 	static Color3 choose( const Color3 & color, QWidget * parent = nullptr );
 	static Color4 choose( const Color4 & color, QWidget * parent = nullptr );
+	static Color3 choose( const Vector3 & color, QWidget * parent = nullptr );
 
 	ColorWheel( QWidget * parent = nullptr );
 	ColorWheel( const QColor & c, QWidget * parent = nullptr );


### PR DESCRIPTION
Vector3 is sometimes used to store color data, as in NiPosData animation keys. I added color wheel functionality and background coloring for the Vector3 fields in those cases.

It may be nicer to just use the Color3 type for those fields, but I'm not sure that is possible, since the meaning of the data can only be determined from surrounding context, rather than the block type.

I also changed the text in color fields to be a contrasting color instead of always white. This required switching from `drawDisplay()` to `painter->drawText()`, because otherwise the pen color was being overwritten by the options palette. I had to tinker with a few things to get it to look the same as before using this new function. I believe I was able to get everything to look the same as before, except the text field ellipsis. Now, if the column is narrower than the text, the text will be clipped without adding "..." to the end. I'm not sure why.