### PR TITLE
Add configurable Auto-Sanitize exclusions and preserve Starfield camera names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Generated
+.build-autosanitize/
 .moc/
 .obj/
 .qrc/
@@ -75,3 +76,6 @@ vc100.pdb
 
 # VSCode
 .vscode/
+
+# Locally supplied game assets used for regression testing (not redistributed)
+/tests/fixtures/fr017/*.nif

--- a/AUTOSANITIZE.md
+++ b/AUTOSANITIZE.md
@@ -1,0 +1,117 @@
+# Auto-sanitize exclusions (FR-017)
+
+Auto-sanitize can skip selected block types for individual modifying operations.
+Open **Settings > Auto-Sanitize**, select an operation and game, then add a block
+type. **Include derived types** also matches subclasses (including the selected
+type itself). Apply or Save writes the configuration; Cancel discards unapplied
+changes. **Reset Custom Exclusions** clears all custom rules when applied.
+**Reload File** reads external edits and offers to discard unapplied changes.
+
+The panel displays the active configuration path and any configuration errors.
+If the file changes externally while the editor has unapplied changes, saving is
+refused until it is reloaded. Failed writes leave the dialog open for correction.
+
+## Built-in Starfield camera protection
+
+`NiCamera` inherits from `NiAVObject`. The existing name sanitizer checks duplicate
+names across `NiAVObject` blocks, including empty names, and can generate a name
+for the second unnamed camera. It can also generate names for invalid string
+indices and names equal to `BSX`.
+
+Starfield cameras and their subclasses are always excluded from **Fix Invalid
+Block Names**, including manual invocation. This protection requires no config
+file and cannot be removed in the editor. Existing names and name indices are
+preserved; this is prevention of sanitizer-induced changes, not a repair of an
+already named or otherwise invalid camera. Older games retain their existing
+default behavior. Runtime compatibility with those games has not been asserted.
+
+## File location
+
+The first existing file below is used, without merging the two files:
+
+1. `NifTools/NifSkope/autosanitize.ini` under Qt's user configuration directory
+   (`QStandardPaths::GenericConfigLocation`).
+2. `autosanitize.ini` beside the executable, for portable installations.
+
+When neither exists, the editor creates the user configuration file. The location
+is independent of the application's GUI/headless application name. Place a file
+beside the executable before opening Settings to use portable configuration when
+no user file exists. The editor writes back to the displayed path; a read-only
+portable file results in a visible save error, not a silent switch of location.
+
+The configuration is read once at the start of each `SpellBook::sanitize` call.
+GUI saves, headless `sanitizeBeforeSave`, and batch sanitize all use this pipeline.
+An edit therefore takes effect on the next sanitize invocation, without restarting.
+The existing **Auto Sanitize before Save** switch is unchanged.
+
+## INI format
+
+Section names and block type names are case-sensitive and are not translated.
+`BlockTypes` matches exact types. `DerivedBlockTypes` matches a type and its
+subclasses. Comma-separated lists use Qt's INI syntax.
+
+```ini
+[fix-invalid-block-names]
+BlockTypes=NiCamera
+starfield\DerivedBlockTypes=NiNode
+
+[collapse-link-arrays]
+BlockTypes=NiNode, BSFadeNode
+
+[reorder-link-arrays]
+BlockTypes=NiNode, BSFadeNode
+```
+
+Unprefixed keys apply to all games; a game prefix restricts the rule to that game.
+The example's first rule preserves camera names in **all** games, extending the
+built-in Starfield protection. The second preserves Starfield node names,
+including derived node types. The remaining rules preserve link arrays owned by
+the two specified exact block types during both operations that can collapse them.
+
+Supported game prefixes: `other`, `morrowind`, `oblivion`, `fallout-3-nv`, `skyrim`,
+`skyrim-se`, `fallout-4`, `fallout-76`, `starfield`. Detection uses the existing
+`GameManager::get_game` version mapping, not the configured resource paths.
+
+| Operation section | Excluded processing |
+| --- | --- |
+| `fix-invalid-block-names` | Name repair and the root-material repair within that spell |
+| `reorder-link-arrays` | Child-link sorting and empty-child pruning |
+| `collapse-link-arrays` | Empty link removal in supported arrays |
+| `adjust-texture-sources` | Texture source path and format preference adjustment |
+| `fix-geometry-data-names` | Fallout 3/NV geometry-data Group ID repair |
+
+Rules protect fields owned by the matching block. They do not freeze references
+to that block stored in other blocks. Operations are independent: excluding a
+node from Collapse Link Arrays alone does not stop Reorder Link Arrays from
+pruning empty children. Validation remains enabled, including Check Links and
+the existing error checkers. Reorder Blocks remains outside auto-sanitize.
+
+Custom rules do not apply to individually invoked spells. The built-in Starfield
+camera protection does apply to the manually invoked naming spell.
+
+Unknown keys and block types are reported and ignored by processing. The editor
+preserves unknown keys and shows unknown types in their corresponding lists so
+they can be removed. Malformed/unreadable files disable custom rules for that
+invocation while retaining built-in protection; the editor refuses to overwrite
+a malformed file. Correct it externally and reload. Qt may reformat the INI file
+on save; comments and original whitespace are not preserved.
+
+## Regression tests
+
+The optional `autosanitize_tests` qmake configuration builds the regression suite
+with the application's real model, spells, and settings page. It requires Qt Test
+in addition to the normal build dependencies and initialized submodules.
+
+```sh
+mkdir -p .build-autosanitize
+cd .build-autosanitize
+qmake6 ../NifSkope.pro CONFIG+=autosanitize_tests noavx2=1
+make -j8
+QT_QPA_PLATFORM=offscreen ./release/tst_autosanitize
+```
+
+The tests create synthetic NIFs and temporary configuration, checking camera
+preservation through sanitize/save/reload, older-game behavior, custom rule
+matching, operation isolation, malformed configuration, and editor persistence.
+These tests do not establish in-game crash behavior; verify with a representative
+Starfield camera asset and game runtime before making that compatibility claim.

--- a/NifSkope.pro
+++ b/NifSkope.pro
@@ -156,6 +156,8 @@ include(NifSkope_targets.pri)
 INCLUDEPATH += src lib
 
 HEADERS += \
+	src/autosanitize.h \
+	src/ui/settingssanitize.h \
 	src/data/nifitem.h \
 	src/data/niftypes.h \
 	src/data/nifvalue.h \
@@ -238,6 +240,8 @@ HEADERS += \
 	lib/xxhash.h
 
 SOURCES += \
+	src/autosanitize.cpp \
+	src/ui/settingssanitize.cpp \
 	src/data/nifitem.cpp \
 	src/data/niftypes.cpp \
 	src/data/nifvalue.cpp \
@@ -503,6 +507,20 @@ macx {
 }
 
 
+# Build the focused regression suite against the same sources and dependencies.
+# Configure Qt Test before constructing the Windows runtime deployment commands.
+autosanitize_tests {
+	TEMPLATE = app
+	TARGET = tst_autosanitize
+	# The normal build uses relative library flags; tests also support a separate build directory.
+	INCLUDEPATH += $$PWD/lib/libfo76utils/src $$PWD/lib/qhull/src $$PWD/lib/gli/gli $$PWD/lib/gli/external
+	QT += testlib
+	CONFIG += console testcase
+	CONFIG -= app_bundle
+	DEFINES += NIFSKOPE_TESTS
+	SOURCES += tests/tst_autosanitize.cpp
+}
+
 # Pre/Post Link in build_pass only
 build_pass|!debug_and_release {
 
@@ -546,6 +564,7 @@ build_pass|!debug_and_release {
 	copyDirs( $$SHADERS, shaders )
 	#copyDirs( $$LANG, lang )
 	copyFiles( $$XML $$QSS res/qt.conf )
+	copyFiles( AUTOSANITIZE.md )
 
 	# Copy Readmes and rename to TXT
 	copyFiles( $$READMES,,,, md:txt )

--- a/NifSkope_functions.pri
+++ b/NifSkope_functions.pri
@@ -151,6 +151,7 @@ defineReplace(QtBins) {
 	list =
 
 	for(m, modules) {
+		equals(m, testlib):m = Test
 		list += $$sprintf($$[QT_INSTALL_BINS]/$${DLLSTRING}, $$m)$${DLLEXT}
 	}
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Running with **-no-gui** and no further option prints a usage summary and exits 
 | `--ReorderBlocks` | `<path>` | Reorder blocks so the game can properly load them. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
 | `--SanitizeBeforeSave` | `<path>` | Fix minor errors (for example duplicate block names) before save. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
 
+#### Auto-sanitize exclusions
+
+Use **Settings > Auto-Sanitize** to exclude block types from individual automatic
+operations. Starfield camera names have built-in protection. See the
+[configuration and editor guide](AUTOSANITIZE.md) for details.
+
 #### Building from source code (Qt 6)
 
 Compiling NifSkope requires Qt 6.4 or newer, or Qt 5.15. On Windows, [MSYS2](https://www.msys2.org/) can be used for building. After running the MSYS2 installer, use the following commands in the MSYS2-UCRT64 shell to install required packages:
@@ -136,4 +142,3 @@ Refer to these other documents in your installation folder or at the links provi
 ## [CONTRIBUTORS](https://github.com/fo76utils/nifskope/blob/develop/CONTRIBUTORS.md)
 
 ## [LICENSE](https://github.com/fo76utils/nifskope/blob/develop/LICENSE.md)
-

--- a/build/README.md.in
+++ b/build/README.md.in
@@ -75,6 +75,12 @@ Running with **-no-gui** and no further option prints a usage summary and exits 
 | `--ReorderBlocks` | `<path>` | Reorder blocks so the game can properly load them. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
 | `--SanitizeBeforeSave` | `<path>` | Fix minor errors (for example duplicate block names) before save. `<path>` may be a single `.nif` file or a folder; folders are searched recursively. Files are overwritten in-place. |
 
+#### Auto-sanitize exclusions
+
+Use **Settings > Auto-Sanitize** to exclude block types from individual automatic
+operations. Starfield camera names have built-in protection. See the
+[configuration and editor guide](AUTOSANITIZE.md) for details.
+
 #### Building from source code (Qt 6)
 
 Compiling NifSkope requires Qt 6.4 or newer, or Qt 5.15. On Windows, [MSYS2](https://www.msys2.org/) can be used for building. After running the MSYS2 installer, use the following commands in the MSYS2-UCRT64 shell to install required packages:
@@ -136,4 +142,3 @@ Refer to these other documents in your installation folder or at the links provi
 ## [CONTRIBUTORS](https://github.com/fo76utils/nifskope/blob/develop/CONTRIBUTORS.md)
 
 ## [LICENSE](https://github.com/fo76utils/nifskope/blob/develop/LICENSE.md)
-

--- a/src/autosanitize.cpp
+++ b/src/autosanitize.cpp
@@ -1,0 +1,165 @@
+#include "autosanitize.h"
+
+#include "gamemanager.h"
+#include "model/nifmodel.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QSettings>
+#include <QStandardPaths>
+
+QString AutoSanitizePolicy::operationId( Operation operation )
+{
+	static const char * ids[] = {
+		"fix-invalid-block-names", "reorder-link-arrays", "collapse-link-arrays",
+		"adjust-texture-sources", "fix-geometry-data-names"
+	};
+	return QString::fromLatin1( ids[operation] );
+}
+
+QString AutoSanitizePolicy::operationName( Operation operation )
+{
+	static const char * names[] = {
+		QT_TRANSLATE_NOOP( "Spell", "Fix Invalid Block Names" ),
+		QT_TRANSLATE_NOOP( "Spell", "Reorder Link Arrays" ),
+		QT_TRANSLATE_NOOP( "Spell", "Collapse Link Arrays" ),
+		QT_TRANSLATE_NOOP( "Spell", "Adjust Texture Sources" ),
+		QT_TRANSLATE_NOOP( "Spell", "Fix Geometry Data Names" )
+	};
+	return QCoreApplication::translate( "Spell", names[operation] );
+}
+
+QStringList AutoSanitizePolicy::scopes()
+{
+	// Non-empty entries follow Game::GameMode order.
+	return { "", "other", "morrowind", "oblivion", "fallout-3-nv", "skyrim",
+		"skyrim-se", "fallout-4", "fallout-76", "starfield" };
+}
+
+QString AutoSanitizePolicy::scopeName( const QString & scope )
+{
+	int index = scopes().indexOf( scope );
+	if ( index == 0 )
+		return QCoreApplication::translate( "AutoSanitizePolicy", "All games" );
+	return index > 0 ? Game::StringForMode( Game::GameMode(index - 1) ) : scope;
+}
+
+QString AutoSanitizePolicy::configPath()
+{
+	// Use a fixed application component so GUI and headless invocations share rules.
+	QString userPath = QStandardPaths::writableLocation( QStandardPaths::GenericConfigLocation )
+		+ "/NifTools/NifSkope/autosanitize.ini";
+	QString portablePath = QCoreApplication::applicationDirPath() + "/autosanitize.ini";
+	if ( QFileInfo::exists( userPath ) || !QFileInfo::exists( portablePath ) )
+		return userPath;
+	return portablePath;
+}
+
+QString AutoSanitizePolicy::ruleKey( Operation operation, const QString & scope, bool derived )
+{
+	return operationId( operation ) + "/" + (scope.isEmpty() ? QString() : scope + "/")
+		+ (derived ? "DerivedBlockTypes" : "BlockTypes");
+}
+
+void AutoSanitizePolicy::load( const QString & path )
+{
+	rules.clear();
+	diagnostics.clear();
+	QSettings settings( path, QSettings::IniFormat );
+	QStringList knownKeys;
+	for ( int op = 0; op < OperationCount; op++ ) {
+		for ( const QString & scope : scopes() ) {
+			for ( bool derived : { false, true } )
+				knownKeys.append( ruleKey( Operation(op), scope, derived ) );
+		}
+	}
+	const QStringList knownTypes = NifModel::allNiBlocks( true );
+	for ( const QString & key : settings.allKeys() ) {
+		if ( !knownKeys.contains( key ) ) {
+			diagnostics.append( QCoreApplication::translate( "AutoSanitizePolicy",
+				"Unknown setting: %1 (preserved, ignored by auto-sanitize)." ).arg( key ) );
+			continue;
+		}
+		QStringList types;
+		for ( const QString & value : settings.value( key ).toStringList() ) {
+			QString type = value.trimmed();
+			if ( type.isEmpty() || types.contains( type ) )
+				continue;
+			types.append( type );
+			if ( !knownTypes.contains( type ) ) {
+				diagnostics.append( QCoreApplication::translate( "AutoSanitizePolicy",
+					"Unknown block type in %1: %2 (ignored)." ).arg( key, type ) );
+			}
+		}
+		rules.insert( key, types );
+	}
+	formatError = settings.status() != QSettings::NoError;
+	if ( formatError ) {
+		diagnostics.append( QCoreApplication::translate( "AutoSanitizePolicy",
+			"Cannot read %1. Custom exclusions were not loaded; built-in protection remains active." ).arg( path ) );
+		rules.clear();
+	}
+}
+
+bool AutoSanitizePolicy::save( const QString & path, QString & error ) const
+{
+	error.clear();
+	if ( formatError ) {
+		error = QCoreApplication::translate( "AutoSanitizePolicy",
+			"Correct the configuration file and reload it before saving." );
+		return false;
+	}
+	if ( !QDir().mkpath( QFileInfo(path).absolutePath() ) ) {
+		error = QCoreApplication::translate( "AutoSanitizePolicy", "Cannot create the configuration directory for %1." ).arg( path );
+		return false;
+	}
+	QSettings settings( path, QSettings::IniFormat );
+	// Read before writing, preserving unrelated keys and refusing malformed files.
+	settings.allKeys();
+	if ( settings.status() == QSettings::NoError ) {
+		for ( int op = 0; op < OperationCount; op++ ) {
+			for ( const QString & scope : scopes() ) {
+				for ( bool derived : { false, true } ) {
+					QString key = ruleKey( Operation(op), scope, derived );
+					if ( rules.value( key ).isEmpty() )
+						settings.remove( key );
+					else
+						settings.setValue( key, rules.value( key ) );
+				}
+			}
+		}
+		settings.sync();
+	}
+	if ( settings.status() != QSettings::NoError ) {
+		error = QCoreApplication::translate( "AutoSanitizePolicy", "Could not save %1. Check its syntax and write permissions." ).arg( path );
+		return false;
+	}
+	return true;
+}
+
+bool AutoSanitizePolicy::protectsCamera( const NifModel * nif, const QModelIndex & block )
+{
+	return nif && block.isValid() && Game::GameManager::get_game( nif ) == Game::STARFIELD
+		&& nif->blockInherits( block, "NiCamera" );
+}
+
+bool AutoSanitizePolicy::excludes( Operation operation, const NifModel * nif, const QModelIndex & block ) const
+{
+	if ( !nif || !block.isValid() )
+		return false;
+	if ( operation == FixNames && protectsCamera( nif, block ) )
+		return true;
+	QString gameScope = scopes().value( int(Game::GameManager::get_game( nif )) + 1 );
+	for ( const QString & scope : { QString(), gameScope } ) {
+		for ( const QString & type : rules.value( ruleKey( operation, scope, false ) ) ) {
+			if ( nif->isNiBlock( block, type ) )
+				return true;
+		}
+		for ( const QString & type : rules.value( ruleKey( operation, scope, true ) ) ) {
+			if ( nif->blockInherits( block, type ) )
+				return true;
+		}
+	}
+	return false;
+}

--- a/src/autosanitize.h
+++ b/src/autosanitize.h
@@ -1,0 +1,37 @@
+#ifndef AUTOSANITIZE_H
+#define AUTOSANITIZE_H
+
+#include <QMap>
+#include <QModelIndex>
+#include <QStringList>
+
+class NifModel;
+
+//! Per-operation exclusions for the automatic sanitize pipeline.
+class AutoSanitizePolicy
+{
+public:
+	enum Operation { FixNames, ReorderLinks, CollapseLinks, AdjustTextures, FixGeometryData, OperationCount };
+
+	static QString operationId( Operation operation );
+	static QString operationName( Operation operation );
+	//! Empty scope means all games. Other scopes use stable, untranslated identifiers.
+	static QStringList scopes();
+	static QString scopeName( const QString & scope );
+	static QString configPath();
+	static QString ruleKey( Operation operation, const QString & scope, bool derived );
+
+	void load( const QString & path );
+	bool save( const QString & path, QString & error ) const;
+	bool excludes( Operation operation, const NifModel * nif, const QModelIndex & block ) const;
+	static bool protectsCamera( const NifModel * nif, const QModelIndex & block );
+
+	// Retain unknown types for editing and forward compatibility; they never match a block.
+	QMap<QString, QStringList> rules;
+	QStringList diagnostics;
+
+private:
+	bool formatError = false;
+};
+
+#endif // AUTOSANITIZE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ QCoreApplication * createApplication( int &argc, char *argv[] )
  */
 
 //! The main program
+#ifndef NIFSKOPE_TESTS
 int main( int argc, char * argv[] )
 {
 	QScopedPointer<QCoreApplication> app( createApplication( argc, argv ) );
@@ -844,6 +845,7 @@ int main( int argc, char * argv[] )
 
 	return 0;
 }
+#endif
 
 
 

--- a/src/model/nifmodel.h
+++ b/src/model/nifmodel.h
@@ -265,8 +265,8 @@ public:
 	//! Move a block in the list
 	void moveNiBlock( int src, int dst );
 
-	//! Returns a list with all known NiXXX ids (<niobject abstract="0">)
-	static QStringList allNiBlocks();
+	//! Returns known block ids, optionally including abstract base types.
+	static QStringList allNiBlocks( bool includeAbstract = false );
 	//! Reorders the blocks according to a list of new block numbers
 	void reorderBlocks( const QVector<qint32> & order );
 	//! Moves all niblocks from this nif to another nif, returns a map which maps old block numbers to new block numbers
@@ -887,11 +887,11 @@ inline NifItem * NifModel::getFooterItem()
 	return const_cast<NifItem *>( const_cast<const NifModel *>(this)->getFooterItem() );
 }
 
-inline QStringList NifModel::allNiBlocks()
+inline QStringList NifModel::allNiBlocks( bool includeAbstract )
 {
 	QStringList lst;
 	for ( NifBlockPtr blk : blocks ) {
-		if ( !blk->abstract )
+		if ( includeAbstract || !blk->abstract )
 			lst.append( blk->id );
 	}
 	return lst;

--- a/src/spellbook.cpp
+++ b/src/spellbook.cpp
@@ -31,6 +31,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***** END LICENCE BLOCK *****/
 
 #include "spellbook.h"
+#include "autosanitize.h"
 
 #include "ui/checkablemessagebox.h"
 
@@ -303,10 +304,14 @@ SpellPtr SpellBook::instant( const NifModel * nif, const QModelIndex & index )
 QModelIndex SpellBook::sanitize( NifModel * nif )
 {
 	QPersistentModelIndex ridx;
+	AutoSanitizePolicy policy;
+	policy.load( AutoSanitizePolicy::configPath() );
+	for ( const QString & diagnostic : policy.diagnostics )
+		qCWarning( nsSpell ) << diagnostic;
 
 	for ( SpellPtr spell : sanitizers() ) {
 		if ( spell->isApplicable( nif, QModelIndex() ) ) {
-			QModelIndex idx = spell->cast( nif, QModelIndex() );
+			QModelIndex idx = spell->castSanitize( nif, policy );
 
 			if ( idx.isValid() && !ridx.isValid() )
 				ridx = idx;

--- a/src/spellbook.h
+++ b/src/spellbook.h
@@ -51,6 +51,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using QIconPtr = std::shared_ptr<QIcon>;
 
+class AutoSanitizePolicy;
+
 //! \file spellbook.h Spell, SpellBook and Librarian
 
 //! Register a Spell using a Librarian
@@ -91,6 +93,12 @@ public:
 
 	//! Cast (apply) the spell
 	virtual QModelIndex cast( NifModel * nif, const QModelIndex & index ) = 0;
+
+	//! Automatic invocation, with optional per-block exclusions in modifying spells.
+	virtual QModelIndex castSanitize( NifModel * nif, const AutoSanitizePolicy & )
+	{
+		return cast( nif, QModelIndex() );
+	}
 
 	//! Cast the spell if applicable
 	void castIfApplicable( NifModel * nif, const QModelIndex & index )

--- a/src/spells/fo3only.cpp
+++ b/src/spells/fo3only.cpp
@@ -1,4 +1,5 @@
 #include "spellbook.h"
+#include "autosanitize.h"
 
 
 // Brief description is deliberately not autolinked to class Spell
@@ -31,15 +32,27 @@ public:
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & index ) override final
 	{
+		return sanitize( nif, index, nullptr );
+	}
+
+	QModelIndex castSanitize( NifModel * nif, const AutoSanitizePolicy & policy ) override final
+	{
+		return sanitize( nif, QModelIndex(), &policy );
+	}
+
+private:
+	QModelIndex sanitize( NifModel * nif, const QModelIndex & index, const AutoSanitizePolicy * policy )
+	{
 		if ( index.isValid() && nif->getBlockIndex( index, "NiGeometryData" ).isValid() ) {
-			nif->set<int>( index, "Group ID", 0 );
+			if ( !policy || !policy->excludes( AutoSanitizePolicy::FixGeometryData, nif, index ) )
+				nif->set<int>( index, "Group ID", 0 );
 		} else {
 			// set all blocks
 			for ( int n = 0; n < nif->getBlockCount(); n++ ) {
 				QModelIndex iBlock = nif->getBlockIndex( n );
 
 				if ( nif->getBlockIndex( iBlock, "NiGeometryData" ).isValid() ) {
-					cast( nif, iBlock );
+					sanitize( nif, iBlock, policy );
 				}
 			}
 		}
@@ -49,4 +62,3 @@ public:
 };
 
 REGISTER_SPELL( spFO3FixShapeDataName )
-

--- a/src/spells/sanitize.cpp
+++ b/src/spells/sanitize.cpp
@@ -483,8 +483,12 @@ private:
 			// Empty camera names are intentional in Starfield. Never generate names for them,
 			// including when this spell is invoked manually or the config cannot be loaded.
 			if ( AutoSanitizePolicy::protectsCamera( nif, iBlock )
-				|| (policy && policy->excludes( AutoSanitizePolicy::FixNames, nif, iBlock )) )
+				|| (policy && policy->excludes( AutoSanitizePolicy::FixNames, nif, iBlock )) ) {
+				if ( nif->blockInherits( iBlock, "NiAVObject" )
+					&& nif->get<int>( iBlock, "Name" ) < numStrings )
+					shapeNames << nif->get<QString>( iBlock, "Name" );
 				continue;
+			}
 			if ( !(nif->blockInherits( iBlock, "NiObjectNET" ) || nif->blockInherits( iBlock, "NiExtraData" )) )
 				continue;
 

--- a/src/spells/sanitize.cpp
+++ b/src/spells/sanitize.cpp
@@ -1,4 +1,5 @@
 #include "spellbook.h"
+#include "autosanitize.h"
 #include "sanitize.h"
 #include "spells/misc.h"
 
@@ -52,8 +53,21 @@ public:
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & ) override
 	{
+		return sanitize( nif, nullptr );
+	}
+
+	QModelIndex castSanitize( NifModel * nif, const AutoSanitizePolicy & policy ) override
+	{
+		return sanitize( nif, &policy );
+	}
+
+private:
+	QModelIndex sanitize( NifModel * nif, const AutoSanitizePolicy * policy )
+	{
 		for ( int n = 0; n < nif->getBlockCount(); n++ ) {
 			QModelIndex iBlock = nif->getBlockIndex( n );
+			if ( policy && policy->excludes( AutoSanitizePolicy::ReorderLinks, nif, iBlock ) )
+				continue;
 
 			QModelIndex iNumChildren = nif->getIndex( iBlock, "Num Children" );
 			QModelIndex iChildren = nif->getIndex( iBlock, "Children" );
@@ -109,8 +123,21 @@ public:
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & ) override final
 	{
+		return sanitize( nif, nullptr );
+	}
+
+	QModelIndex castSanitize( NifModel * nif, const AutoSanitizePolicy & policy ) override final
+	{
+		return sanitize( nif, &policy );
+	}
+
+private:
+	QModelIndex sanitize( NifModel * nif, const AutoSanitizePolicy * policy )
+	{
 		for ( int n = 0; n < nif->getBlockCount(); n++ ) {
 			QModelIndex iBlock = nif->getBlockIndex( n );
+			if ( policy && policy->excludes( AutoSanitizePolicy::CollapseLinks, nif, iBlock ) )
+				continue;
 
 			spCollapseArray arrayCollapser;
 
@@ -161,8 +188,21 @@ public:
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & ) override final
 	{
+		return sanitize( nif, nullptr );
+	}
+
+	QModelIndex castSanitize( NifModel * nif, const AutoSanitizePolicy & policy ) override final
+	{
+		return sanitize( nif, &policy );
+	}
+
+private:
+	QModelIndex sanitize( NifModel * nif, const AutoSanitizePolicy * policy )
+	{
 		for ( int i = 0; i < nif->getBlockCount(); i++ ) {
 			QModelIndex iTexSrc = nif->getBlockIndex( i, "NiSourceTexture" );
+			if ( policy && policy->excludes( AutoSanitizePolicy::AdjustTextures, nif, iTexSrc ) )
+				continue;
 
 			if ( iTexSrc.isValid() ) {
 				QModelIndex iFileName = nif->getIndex( iTexSrc, "File Name" );
@@ -392,6 +432,17 @@ public:
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & ) override final
 	{
+		return sanitize( nif, nullptr );
+	}
+
+	QModelIndex castSanitize( NifModel * nif, const AutoSanitizePolicy & policy ) override final
+	{
+		return sanitize( nif, &policy );
+	}
+
+private:
+	QModelIndex sanitize( NifModel * nif, const AutoSanitizePolicy * policy )
+	{
 		QVector<QString> stringsToAdd;
 		QVector<QString> shapeNames;
 		QMap<QModelIndex, QString> modifiedBlocks;
@@ -429,6 +480,11 @@ public:
 
 		for ( int i = 0; i < nif->getBlockCount(); i++ ) {
 			QModelIndex iBlock = nif->getBlockIndex( i );
+			// Empty camera names are intentional in Starfield. Never generate names for them,
+			// including when this spell is invoked manually or the config cannot be loaded.
+			if ( AutoSanitizePolicy::protectsCamera( nif, iBlock )
+				|| (policy && policy->excludes( AutoSanitizePolicy::FixNames, nif, iBlock )) )
+				continue;
 			if ( !(nif->blockInherits( iBlock, "NiObjectNET" ) || nif->blockInherits( iBlock, "NiExtraData" )) )
 				continue;
 

--- a/src/ui/settingsdialog.cpp
+++ b/src/ui/settingsdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_settingsdialog.h"
 
 #include "ui/settingspane.h"
+#include "ui/settingssanitize.h"
 
 #include <QDebug>
 #include <QListWidget>
@@ -28,6 +29,8 @@ SettingsDialog::SettingsDialog( QWidget * parent ) :
 	content->addWidget( new SettingsGeneral( this ) );
 	content->addWidget( new SettingsRender( this ) );
 	content->addWidget( new SettingsResources( this ) );
+	sanitizePane = new SettingsSanitize( this );
+	content->addWidget( sanitizePane );
 
 	categories->setCurrentRow( 0 );
 
@@ -72,20 +75,24 @@ void SettingsDialog::registerPage( QWidget * parent, const QString & text )
 		p->categories->addItem( text );
 }
 
-void SettingsDialog::apply()
+bool SettingsDialog::apply()
 {
+	// A configuration write failure must leave Save/Apply available and the dialog open.
+	if ( !sanitizePane->saveChanges() )
+		return false;
 	emit saveSettings();
 	emit update3D();
 
 	btnSave->setEnabled( false );
 	btnApply->setEnabled( false );
 	btnCancel->setText( tr("Close") );
+	return true;
 }
 
 void SettingsDialog::save()
 {
-	apply();
-	close();
+	if ( apply() )
+		close();
 }
 
 void SettingsDialog::cancel()
@@ -102,7 +109,9 @@ void SettingsDialog::cancel()
 void SettingsDialog::restoreDefaults()
 {
 	auto tmpDlg = std::unique_ptr<SettingsDialog>( new SettingsDialog );
-	tmpDlg->save();
+	tmpDlg->sanitizePane->setDefault();
+	if ( !tmpDlg->apply() )
+		return;
 
 	loadSettings();
 }

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -14,6 +14,7 @@ class QListWidgetItem;
 class QPushButton;
 class QStackedWidget;
 class GLView;
+class SettingsSanitize;
 
 namespace Ui {
 class SettingsDialog;
@@ -38,7 +39,7 @@ public:
 
 public slots:
 	void save();
-	void apply();
+	bool apply();
 	void cancel();
 	void changePage( QListWidgetItem * current, QListWidgetItem * previous );
 	void restoreDefaults();
@@ -53,6 +54,7 @@ signals:
 
 private:
 	std::unique_ptr<Ui::SettingsDialog> ui;
+	SettingsSanitize * sanitizePane;
 
 	QPushButton * btnSave;
 	QPushButton * btnApply;

--- a/src/ui/settingssanitize.cpp
+++ b/src/ui/settingssanitize.cpp
@@ -1,0 +1,184 @@
+#include "settingssanitize.h"
+#include "settingsdialog.h"
+
+#include "model/nifmodel.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFile>
+#include <QFormLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+SettingsSanitize::SettingsSanitize( QWidget * parent ) : SettingsPane( parent )
+{
+	SettingsDialog::registerPage( parent, tr( "Auto-Sanitize" ) );
+	auto layout = new QVBoxLayout( this );
+	auto explanation = new QLabel( tr( "Exclude block types from individual auto-sanitize operations. "
+		"All-games rules and game-specific rules are combined. Validation still runs." ), this );
+	explanation->setWordWrap( true );
+	layout->addWidget( explanation );
+	auto form = new QFormLayout;
+	operation = new QComboBox( this );
+	operation->setObjectName( "sanitizeOperation" );
+	for ( int op = 0; op < AutoSanitizePolicy::OperationCount; op++ )
+		operation->addItem( AutoSanitizePolicy::operationName( AutoSanitizePolicy::Operation(op) ) );
+	scope = new QComboBox( this );
+	scope->setObjectName( "sanitizeScope" );
+	for ( const QString & id : AutoSanitizePolicy::scopes() )
+		scope->addItem( AutoSanitizePolicy::scopeName( id ), id );
+	form->addRow( tr( "Operation" ), operation );
+	form->addRow( tr( "Game" ), scope );
+	layout->addLayout( form );
+	exclusions = new QListWidget( this );
+	exclusions->setObjectName( "sanitizeExclusions" );
+	exclusions->setAccessibleName( tr( "Excluded block types" ) );
+	exclusions->setSelectionMode( QAbstractItemView::ExtendedSelection );
+	layout->addWidget( exclusions );
+	auto addRow = new QHBoxLayout;
+	blockType = new QComboBox( this );
+	blockType->setObjectName( "sanitizeBlockType" );
+	blockType->setAccessibleName( tr( "Block type" ) );
+	blockType->setEditable( true );
+	blockType->setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
+	blockType->setMinimumContentsLength( 20 );
+	blockType->setInsertPolicy( QComboBox::NoInsert );
+	QStringList types = NifModel::allNiBlocks( true );
+	types.sort();
+	blockType->addItems( types );
+	includeDerived = new QCheckBox( tr( "Include derived types" ), this );
+	includeDerived->setObjectName( "sanitizeIncludeDerived" );
+	auto add = new QPushButton( tr( "Add" ), this );
+	add->setObjectName( "sanitizeAdd" );
+	addRow->addWidget( blockType, 1 );
+	addRow->addWidget( includeDerived );
+	addRow->addWidget( add );
+	layout->addLayout( addRow );
+	auto buttons = new QHBoxLayout;
+	auto remove = new QPushButton( tr( "Remove Selected" ), this );
+	remove->setObjectName( "sanitizeRemove" );
+	auto reset = new QPushButton( tr( "Reset Custom Exclusions" ), this );
+	reset->setObjectName( "sanitizeReset" );
+	auto reload = new QPushButton( tr( "Reload File" ), this );
+	buttons->addWidget( remove );
+	buttons->addWidget( reset );
+	buttons->addStretch();
+	buttons->addWidget( reload );
+	layout->addLayout( buttons );
+	auto protection = new QLabel( tr( "Built-in protection: Starfield NiCamera blocks (including derived types) "
+		"are excluded from Fix Invalid Block Names, including manual invocation. This rule cannot be removed. "
+		"Existing names are preserved, not cleared." ), this );
+	protection->setWordWrap( true );
+	layout->addWidget( protection );
+	configLocation = new QLabel( this );
+	configLocation->setWordWrap( true );
+	configLocation->setTextFormat( Qt::PlainText );
+	configLocation->setTextInteractionFlags( Qt::TextSelectableByMouse );
+	layout->addWidget( configLocation );
+	diagnostics = new QPlainTextEdit( this );
+	diagnostics->setAccessibleName( tr( "Configuration errors" ) );
+	diagnostics->setReadOnly( true );
+	diagnostics->setMaximumHeight( 80 );
+	diagnostics->setPlaceholderText( tr( "No configuration errors." ) );
+	layout->addWidget( diagnostics );
+	connect( operation, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &SettingsSanitize::refreshRules );
+	connect( scope, QOverload<int>::of( &QComboBox::currentIndexChanged ), this, &SettingsSanitize::refreshRules );
+	connect( add, &QPushButton::clicked, this, [this]() {
+		QString type = blockType->currentText().trimmed();
+		if ( blockType->findText( type, Qt::MatchExactly ) < 0 ) {
+			diagnostics->setPlainText( tr( "Select a known block type. Block type names are case-sensitive." ) );
+			return;
+		}
+		if ( NifModel::isAncestor( type ) && !includeDerived->isChecked() ) {
+			diagnostics->setPlainText( tr( "This is an abstract block type. Enable Include derived types to match its subclasses." ) );
+			return;
+		}
+		QString key = currentKey( includeDerived->isChecked() );
+		diagnostics->setPlainText( policy.diagnostics.join( '\n' ) );
+		if ( !policy.rules[key].contains( type ) ) {
+			policy.rules[key].append( type );
+			modifyPane();
+			refreshRules();
+		}
+	} );
+	connect( remove, &QPushButton::clicked, this, [this]() {
+		const auto selected = exclusions->selectedItems();
+		for ( auto item : selected )
+			policy.rules[currentKey( item->data( Qt::UserRole + 1 ).toBool() )].removeAll( item->data( Qt::UserRole ).toString() );
+		if ( !selected.isEmpty() ) {
+			modifyPane();
+			refreshRules();
+		}
+	} );
+	connect( reset, &QPushButton::clicked, this, &SettingsSanitize::setDefault );
+	connect( reload, &QPushButton::clicked, this, [this]() {
+		if ( !isModified() || QMessageBox::question( this, tr( "Reload Auto-Sanitize Configuration" ),
+			tr( "Discard unapplied exclusion changes and reload the file?" ) ) == QMessageBox::Yes )
+			read();
+	} );
+	read();
+}
+
+QString SettingsSanitize::currentKey( bool derived ) const
+{
+	return AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::Operation(operation->currentIndex()), scope->currentData().toString(), derived );
+}
+
+void SettingsSanitize::refreshRules()
+{
+	exclusions->clear();
+	for ( bool derived : { false, true } ) {
+		for ( const QString & type : policy.rules.value( currentKey( derived ) ) ) {
+			auto item = new QListWidgetItem( derived ? tr( "%1 (including derived types)" ).arg( type ) : type, exclusions );
+			item->setData( Qt::UserRole, type );
+			item->setData( Qt::UserRole + 1, derived );
+		}
+	}
+}
+
+void SettingsSanitize::read()
+{
+	path = AutoSanitizePolicy::configPath();
+	policy.load( path );
+	QFile file( path );
+	loadedContents = file.open( QIODevice::ReadOnly ) ? file.readAll() : QByteArray();
+	configLocation->setText( tr( "Configuration: %1" ).arg( path ) );
+	diagnostics->setPlainText( policy.diagnostics.join( '\n' ) );
+	refreshRules();
+	setModified( false );
+}
+
+bool SettingsSanitize::saveChanges()
+{
+	if ( !isModified() )
+		return true;
+	QFile file( path );
+	QByteArray currentContents = file.open( QIODevice::ReadOnly ) ? file.readAll() : QByteArray();
+	file.close();
+	QString error;
+	if ( path != AutoSanitizePolicy::configPath() || currentContents != loadedContents )
+		error = tr( "The configuration file changed outside this editor. Reload it before saving." );
+	else if ( policy.save( path, error ) ) {
+		read();
+		return true;
+	}
+	diagnostics->setPlainText( error );
+	QMessageBox::warning( this, tr( "Auto-Sanitize Configuration" ), error );
+	return false;
+}
+
+void SettingsSanitize::write()
+{
+	saveChanges();
+}
+
+void SettingsSanitize::setDefault()
+{
+	policy.rules.clear();
+	refreshRules();
+	modifyPane();
+}

--- a/src/ui/settingssanitize.h
+++ b/src/ui/settingssanitize.h
@@ -1,0 +1,40 @@
+#ifndef SETTINGSSANITIZE_H
+#define SETTINGSSANITIZE_H
+
+#include "settingspane.h"
+#include "autosanitize.h"
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QListWidget;
+class QPlainTextEdit;
+
+class SettingsSanitize final : public SettingsPane
+{
+	Q_OBJECT
+
+public:
+	explicit SettingsSanitize( QWidget * parent = nullptr );
+	void read() override;
+	void write() override;
+	void setDefault() override;
+	bool saveChanges();
+
+private:
+	void refreshRules();
+	QString currentKey( bool derived ) const;
+
+	AutoSanitizePolicy policy;
+	QString path;
+	QByteArray loadedContents;
+	QComboBox * operation;
+	QComboBox * scope;
+	QComboBox * blockType;
+	QCheckBox * includeDerived;
+	QListWidget * exclusions;
+	QLabel * configLocation;
+	QPlainTextEdit * diagnostics;
+};
+
+#endif // SETTINGSSANITIZE_H

--- a/tests/fixtures/fr017/README.md
+++ b/tests/fixtures/fr017/README.md
@@ -1,0 +1,57 @@
+# FR-017 local camera fixture
+
+`skeleton.nif` is the user-supplied vanilla Starfield asset shared by Imperial
+Sympathiser for camera-name regression testing. It was copied from the user's
+Downloads folder on 2026-09-07. The original download and this fixture must not
+be modified. The binary is kept locally and ignored by Git; it is not included
+in the release package.
+
+- Size: 53,194 bytes
+- SHA-256: `a39578a45a1812c8cd657052f0daed300669a75eedc63f99aa1b97108e74e9da`
+- Expected camera: block 252 (`NiCamera`), blank Name
+
+Set `NIFSKOPE_CAMERA_FIXTURE` to the absolute path of this fixture, then run
+`tst_autosanitize suppliedCameraFixture`. Without the variable, this optional
+test is skipped so upstream builds do not require a proprietary game asset.
+
+The test creates a temporary copy and checks three auto-sanitize/save/reload
+cycles plus manual name repair/save/reload. Each check verifies the camera's
+blank name and original raw name index. It deletes the disposable copy and
+compares the fixture bytes with the original read. A temporary-directory guard
+also cleans up on assertion failure. This checks file processing, not in-game
+Starfield behavior.
+
+## Verified 2026-09-07
+
+Native Windows release test build: Qt 6.11.2, GCC 16.2.0, Windows 11.
+The complete suite passed: **17 passed, 0 failed, 0 skipped**.
+
+The supplied file contains 261 blocks and uses Bethesda stream version 173,
+classified as Starfield by the existing game mapping. Block 252 is a NiCamera
+with an empty name at string index 117. The name remained empty and index 117
+remained unchanged through all three automatic cycles and the manual naming
+cycle. The temporary test copy was deleted. SHA-256 checks before and after
+testing confirmed that both the original download and local fixture match the
+hash above.
+
+Full native test output: `.build-autosanitize/fixture-test.log` at the repository
+root. No desktop video was captured; native desktop recording was unavailable
+in the test session. These results come from the real model and spell pipeline
+in the native regression executable, rather than a manual GUI interaction or
+an in-game test.
+
+## Recorded native GUI verification
+
+After enabling Computer Use, the release GUI was also tested on a disposable
+copy on 2026-09-07. File > Auto Sanitize before Save was visibly checked. Save
+completed, then File > Reload loaded the saved file from disk. Block 252 still
+showed a blank Name at index 117. The saved file's SHA-256 also matched the
+original fixture. The disposable copy was deleted after closing NifSkope.
+
+OBS captured the completed save/reload test in
+`.build-autosanitize/gui-test/FR017-camera-save-reload.mp4` (about two minutes).
+The recording captures only the NifSkope window, with microphone and desktop
+audio muted. An earlier attempt stopped at a Computer Use activation failure
+on the Settings dialog; the completed recording covers the main-window
+save/reload check after that dialog was manually closed. The exclusion editor
+was not manually retested in this recording.

--- a/tests/tst_autosanitize.cpp
+++ b/tests/tst_autosanitize.cpp
@@ -135,9 +135,13 @@ private slots:
 			auto node = nif.insertNiBlock( "NiNode" );
 			QVERIFY( nif.assignString( node, "Name", QStringLiteral("Duplicate") ) );
 		}
+		auto protectedNameCollision = nif.insertNiBlock( "NiNode" );
+		QVERIFY( nif.assignString( protectedNameCollision, "Name", name ) );
 		QVERIFY( nif.sanitizeBeforeSave() );
 		for ( int i = 0; i < 2; i++ )
 			QCOMPARE( nif.get<int>( nif.getBlockIndex( i ), "Name" ), originalIndex );
+		if ( !name.isEmpty() )
+			QVERIFY( nif.get<QString>( protectedNameCollision ) != name );
 		QVERIFY( nif.get<QString>( nif.getBlockIndex( 2 ), "Name" ) != nif.get<QString>( nif.getBlockIndex( 3 ), "Name" ) );
 		auto names = spell( "Fix Invalid Block Names" );
 		QVERIFY( names );

--- a/tests/tst_autosanitize.cpp
+++ b/tests/tst_autosanitize.cpp
@@ -1,0 +1,393 @@
+#include "autosanitize.h"
+#include "gamemanager.h"
+#include "spellbook.h"
+#include "ui/settingssanitize.h"
+#include "ui/settingsdialog.h"
+
+#include <QApplication>
+#include <QBuffer>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QCryptographicHash>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QStackedWidget>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QtTest>
+
+class TestAutoSanitize : public QObject
+{
+	Q_OBJECT
+
+	static void version( int bsVersion, int userVersion = 12 )
+	{
+		QSettings settings;
+		settings.setValue( "Settings/Nif/Startup Defaults/Version", "20.2.0.7" );
+		settings.setValue( "Settings/Nif/Startup Defaults/User Version", userVersion );
+		settings.setValue( "Settings/Nif/Startup Defaults/User Version 2", bsVersion );
+	}
+
+	static SpellPtr spell( const char * name )
+	{
+		return SpellBook::lookup( QString( "Sanitize/" ) + name );
+	}
+
+private slots:
+	void initTestCase()
+	{
+		QVERIFY( NifModel::loadXML() );
+	}
+
+	void init()
+	{
+		QFile::remove( AutoSanitizePolicy::configPath() );
+		version( 170 );
+	}
+
+	void cameraNames_data()
+	{
+		QTest::addColumn<QString>( "name" );
+		QTest::addColumn<int>( "rawIndex" );
+		QTest::newRow( "empty-string" ) << QString() << 0;
+		QTest::newRow( "unset" ) << QString() << -1;
+		QTest::newRow( "invalid-index" ) << QString() << 12345;
+		QTest::newRow( "existing-name" ) << QString( "Camera" ) << -2;
+		QTest::newRow( "bsx-name" ) << QString( "BSX" ) << -2;
+	}
+
+	void suppliedCameraFixture()
+	{
+		const QString source = qEnvironmentVariable( "NIFSKOPE_CAMERA_FIXTURE" );
+		if ( source.isEmpty() )
+			QSKIP( "Set NIFSKOPE_CAMERA_FIXTURE to the local Starfield skeleton.nif fixture." );
+		QFile fixture( source );
+		QVERIFY( fixture.open( QIODevice::ReadOnly ) );
+		const QByteArray original = fixture.readAll();
+		fixture.close();
+		qInfo() << "Fixture SHA256:" << QCryptographicHash::hash( original, QCryptographicHash::Sha256 ).toHex();
+		QTemporaryDir copies;
+		QVERIFY( copies.isValid() );
+		const QString copy = copies.filePath( "skeleton-test.nif" );
+		QVERIFY( QFile::copy( source, copy ) );
+		NifModel nif;
+		QVERIFY( nif.loadFromFile( copy ) );
+		QCOMPARE( Game::GameManager::get_game( &nif ), Game::STARFIELD );
+		qInfo() << "Fixture Bethesda stream version:" << nif.getBSVersion();
+		const int blockCount = nif.getBlockCount();
+		QVERIFY( nif.blockInherits( nif.getBlockIndex( 252 ), "NiCamera" ) );
+		QCOMPARE( nif.get<QString>( nif.getBlockIndex( 252 ), "Name" ), QString() );
+		const int nameIndex = nif.get<int>( nif.getBlockIndex( 252 ), "Name" );
+		qInfo() << "Before: blocks=" << blockCount << "block=252 type=NiCamera name=empty raw-index=" << nameIndex;
+		for ( int pass = 1; pass <= 3; pass++ ) {
+			QVERIFY( nif.sanitizeBeforeSave() );
+			QCOMPARE( nif.get<int>( nif.getBlockIndex( 252 ), "Name" ), nameIndex );
+			QVERIFY( nif.saveToFile( copy ) );
+			QVERIFY( nif.loadFromFile( copy ) );
+			QCOMPARE( nif.getBlockCount(), blockCount );
+			QVERIFY( nif.blockInherits( nif.getBlockIndex( 252 ), "NiCamera" ) );
+			QCOMPARE( nif.get<QString>( nif.getBlockIndex( 252 ), "Name" ), QString() );
+			QCOMPARE( nif.get<int>( nif.getBlockIndex( 252 ), "Name" ), nameIndex );
+			qInfo() << "Auto-sanitize/save/reload pass" << pass << ": camera name still empty; raw index unchanged";
+		}
+		auto names = spell( "Fix Invalid Block Names" );
+		QVERIFY( names );
+		names->cast( &nif, {} );
+		QVERIFY( nif.saveToFile( copy ) );
+		QVERIFY( nif.loadFromFile( copy ) );
+		QCOMPARE( nif.get<QString>( nif.getBlockIndex( 252 ), "Name" ), QString() );
+		QCOMPARE( nif.get<int>( nif.getBlockIndex( 252 ), "Name" ), nameIndex );
+		qInfo() << "Manual name repair/save/reload: camera name still empty; raw index unchanged";
+		QVERIFY( QFile::remove( copy ) );
+		QVERIFY( !QFile::exists( copy ) );
+		QVERIFY( fixture.open( QIODevice::ReadOnly ) );
+		QCOMPARE( fixture.readAll(), original );
+		qInfo() << "Disposable copy deleted; fixture bytes unchanged";
+	}
+
+	void cameraNames()
+	{
+		QFETCH( QString, name );
+		QFETCH( int, rawIndex );
+		NifModel nif;
+		QCOMPARE( nif.getBSVersion(), quint32(170) );
+		if ( rawIndex == 0 ) {
+			auto header = nif.getHeaderIndex();
+			nif.set<int>( header, "Num Strings", 1 );
+			nif.updateArraySize( header, "Strings" );
+			nif.setArray<QString>( header, "Strings", { "" } );
+		}
+		for ( int i = 0; i < 2; i++ ) {
+			auto camera = nif.insertNiBlock( "NiCamera" );
+			QVERIFY( camera.isValid() );
+			QVERIFY( nif.assignString( camera, "Name", name ) );
+			if ( rawIndex != -2 )
+				nif.set<int>( camera, "Name", rawIndex );
+		}
+		int originalIndex = nif.get<int>( nif.getBlockIndex( 1 ), "Name" );
+		// Ordinary duplicate names must still be repaired.
+		for ( int i = 0; i < 2; i++ ) {
+			auto node = nif.insertNiBlock( "NiNode" );
+			QVERIFY( nif.assignString( node, "Name", QStringLiteral("Duplicate") ) );
+		}
+		QVERIFY( nif.sanitizeBeforeSave() );
+		for ( int i = 0; i < 2; i++ )
+			QCOMPARE( nif.get<int>( nif.getBlockIndex( i ), "Name" ), originalIndex );
+		QVERIFY( nif.get<QString>( nif.getBlockIndex( 2 ), "Name" ) != nif.get<QString>( nif.getBlockIndex( 3 ), "Name" ) );
+		auto names = spell( "Fix Invalid Block Names" );
+		QVERIFY( names );
+		names->cast( &nif, {} );
+		QCOMPARE( nif.get<int>( nif.getBlockIndex( 1 ), "Name" ), originalIndex );
+		QBuffer buffer;
+		QVERIFY( buffer.open( QIODevice::ReadWrite ) );
+		QVERIFY( nif.save( buffer ) );
+		QVERIFY( buffer.seek( 0 ) );
+		NifModel reloaded;
+		QVERIFY( reloaded.load( buffer ) );
+		QCOMPARE( reloaded.get<int>( reloaded.getBlockIndex( 1 ), "Name" ), originalIndex );
+		QVERIFY( reloaded.sanitizeBeforeSave() );
+		QCOMPARE( reloaded.get<int>( reloaded.getBlockIndex( 1 ), "Name" ), originalIndex );
+	}
+
+	void olderGameCamera()
+	{
+		version( 100 );
+		NifModel nif;
+		for ( int i = 0; i < 2; i++ )
+			nif.assignString( nif.insertNiBlock( "NiCamera" ), "Name", QString() );
+		QVERIFY( !AutoSanitizePolicy::protectsCamera( &nif, nif.getBlockIndex( 1 ) ) );
+		spell( "Fix Invalid Block Names" )->cast( &nif, {} );
+		QVERIFY( !nif.get<QString>( nif.getBlockIndex( 1 ), "Name" ).isEmpty() );
+	}
+
+	void matchingAndPersistence()
+	{
+		QString path = AutoSanitizePolicy::configPath();
+		{
+			QSettings settings( path, QSettings::IniFormat );
+			settings.setValue( "future-operation/Value", "preserve me" );
+		}
+		AutoSanitizePolicy policy;
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::FixNames, "starfield", false )] = QStringList{ "NiNode" };
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::CollapseLinks, "", true )] = QStringList{ "NiNode" };
+		QString error;
+		QVERIFY2( policy.save( path, error ), qPrintable(error) );
+		AutoSanitizePolicy loaded;
+		loaded.load( path );
+		QCOMPARE( loaded.rules, policy.rules );
+		QCOMPARE( loaded.diagnostics.size(), 1 );
+		NifModel nif;
+		auto node = nif.insertNiBlock( "NiNode" );
+		auto derived = nif.insertNiBlock( "BSFadeNode" );
+		QVERIFY( loaded.excludes( AutoSanitizePolicy::FixNames, &nif, node ) );
+		QVERIFY( !loaded.excludes( AutoSanitizePolicy::FixNames, &nif, derived ) );
+		QVERIFY( loaded.excludes( AutoSanitizePolicy::CollapseLinks, &nif, derived ) );
+		QVERIFY( !loaded.excludes( AutoSanitizePolicy::ReorderLinks, &nif, node ) );
+		version( 100 );
+		NifModel older;
+		auto olderNode = older.insertNiBlock( "NiNode" );
+		QVERIFY( !loaded.excludes( AutoSanitizePolicy::FixNames, &older, olderNode ) );
+		QVERIFY( loaded.excludes( AutoSanitizePolicy::CollapseLinks, &older, olderNode ) );
+		loaded.rules.clear();
+		QVERIFY( loaded.save( path, error ) );
+		QSettings settings( path, QSettings::IniFormat );
+		QCOMPARE( settings.value( "future-operation/Value" ).toString(), QString( "preserve me" ) );
+		QCOMPARE( settings.allKeys().size(), 1 );
+	}
+
+	void pipelineAndManualIsolation()
+	{
+		AutoSanitizePolicy policy;
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::FixNames, "", false )] = QStringList{ "NiNode" };
+		QString error;
+		QVERIFY( policy.save( AutoSanitizePolicy::configPath(), error ) );
+		NifModel nif;
+		for ( int i = 0; i < 2; i++ )
+			nif.assignString( nif.insertNiBlock( "NiNode" ), "Name", QStringLiteral("Same") );
+		SpellBook::sanitize( &nif );
+		QCOMPARE( nif.get<QString>( nif.getBlockIndex( 1 ), "Name" ), QString( "Same" ) );
+		spell( "Fix Invalid Block Names" )->cast( &nif, {} );
+		QVERIFY( nif.get<QString>( nif.getBlockIndex( 1 ), "Name" ) != "Same" );
+	}
+
+	void linkArrayIsolation()
+	{
+		NifModel nif;
+		auto node = nif.insertNiBlock( "NiNode" );
+		nif.set<int>( node, "Num Children", 2 );
+		nif.updateArraySize( node, "Children" );
+		nif.setLinkArray( node, "Children", { -1, -1 } );
+		AutoSanitizePolicy policy;
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::CollapseLinks, "", false )] = QStringList{ "NiNode" };
+		spell( "Collapse Link Arrays" )->castSanitize( &nif, policy );
+		QCOMPARE( nif.get<int>( node, "Num Children" ), 2 );
+		// Reordering also collapses empty children, so its exclusion is independent.
+		spell( "Reorder Link Arrays" )->castSanitize( &nif, policy );
+		QCOMPARE( nif.get<int>( node, "Num Children" ), 0 );
+	}
+
+	void otherModifyingOperations()
+	{
+		version( 34, 11 );
+		NifModel nif;
+		auto texture = nif.insertNiBlock( "NiSourceTexture" );
+		nif.set<quint8>( texture, "Use External", 1 );
+		QVERIFY( nif.assignString( texture, "File Name", QStringLiteral("textures/test.dds") ) );
+		auto data = nif.insertNiBlock( "NiTriShapeData" );
+		nif.set<int>( data, "Group ID", 42 );
+		auto node = nif.insertNiBlock( "NiNode" );
+		nif.set<int>( node, "Num Children", 1 );
+		nif.updateArraySize( node, "Children" );
+		nif.setLinkArray( node, "Children", { -1 } );
+		AutoSanitizePolicy policy;
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::AdjustTextures, "", false )] = QStringList{ "NiSourceTexture" };
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::FixGeometryData, "", true )] = QStringList{ "NiGeometryData" };
+		policy.rules[AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::ReorderLinks, "", false )] = QStringList{ "NiNode" };
+		for ( const char * name : { "Adjust Texture Sources", "Fix Geometry Data Names", "Reorder Link Arrays" } ) {
+			auto operation = spell( name );
+			QVERIFY( operation && operation->isApplicable( &nif, {} ) );
+			operation->castSanitize( &nif, policy );
+		}
+		QCOMPARE( nif.get<QString>( texture, "File Name" ), QString( "textures/test.dds" ) );
+		QCOMPARE( nif.get<int>( data, "Group ID" ), 42 );
+		QCOMPARE( nif.get<int>( node, "Num Children" ), 1 );
+		policy.rules.clear();
+		for ( const char * name : { "Adjust Texture Sources", "Fix Geometry Data Names", "Reorder Link Arrays" } )
+			spell( name )->castSanitize( &nif, policy );
+		QCOMPARE( nif.get<QString>( texture, "File Name" ), QString( "textures\\test.dds" ) );
+		QCOMPARE( nif.get<int>( data, "Group ID" ), 0 );
+		QCOMPARE( nif.get<int>( node, "Num Children" ), 0 );
+	}
+
+	void unknownEntries()
+	{
+		{
+			QSettings settings( AutoSanitizePolicy::configPath(), QSettings::IniFormat );
+			settings.setValue( "fix-invalid-block-names/BlockTypes", QStringList{ "NiNode", "NoSuchBlock", "NiNode" } );
+			settings.setValue( "fix-invalid-block-names/no-such-game/BlockTypes", "NiCamera" );
+		}
+		AutoSanitizePolicy policy;
+		policy.load( AutoSanitizePolicy::configPath() );
+		QCOMPARE( policy.diagnostics.size(), 2 );
+		QCOMPARE( policy.rules.value( "fix-invalid-block-names/BlockTypes" ).size(), 2 );
+		NifModel nif;
+		QVERIFY( policy.excludes( AutoSanitizePolicy::FixNames, &nif, nif.insertNiBlock( "NiNode" ) ) );
+		QString error;
+		QVERIFY( policy.save( AutoSanitizePolicy::configPath(), error ) );
+		policy.load( AutoSanitizePolicy::configPath() );
+		QCOMPARE( policy.diagnostics.size(), 2 );
+	}
+
+	void malformedConfiguration()
+	{
+		QString path = AutoSanitizePolicy::configPath();
+		QDir().mkpath( QFileInfo(path).absolutePath() );
+		QFile file( path );
+		QVERIFY( file.open( QIODevice::WriteOnly ) );
+		file.write( "[broken\nBlockTypes=NiNode\n" );
+		file.close();
+		AutoSanitizePolicy policy;
+		policy.load( path );
+		QVERIFY( !policy.diagnostics.isEmpty() );
+		QVERIFY( policy.rules.isEmpty() );
+		NifModel nif;
+		QVERIFY( policy.excludes( AutoSanitizePolicy::FixNames, &nif, nif.insertNiBlock( "NiCamera" ) ) );
+		QString error;
+		QVERIFY( !policy.save( path, error ) );
+		QVERIFY( !error.isEmpty() );
+	}
+
+	void editorRoundTrip()
+	{
+		SettingsSanitize editor;
+		auto type = editor.findChild<QComboBox *>( "sanitizeBlockType" );
+		auto game = editor.findChild<QComboBox *>( "sanitizeScope" );
+		auto derived = editor.findChild<QCheckBox *>( "sanitizeIncludeDerived" );
+		auto list = editor.findChild<QListWidget *>( "sanitizeExclusions" );
+		auto add = editor.findChild<QPushButton *>( "sanitizeAdd" );
+		QVERIFY( type && game && derived && list && add );
+		game->setCurrentIndex( game->findData( "starfield" ) );
+		type->setEditText( "NotARealBlock" );
+		add->click();
+		QCOMPARE( list->count(), 0 );
+		type->setCurrentText( "NiAVObject" );
+		derived->setChecked( true );
+		add->click();
+		add->click();
+		QCOMPARE( list->count(), 1 );
+		QVERIFY( editor.saveChanges() );
+		AutoSanitizePolicy policy;
+		policy.load( AutoSanitizePolicy::configPath() );
+		QCOMPARE( policy.rules.value( AutoSanitizePolicy::ruleKey( AutoSanitizePolicy::FixNames, "starfield", true ) ), QStringList{ "NiAVObject" } );
+		editor.setDefault();
+		QCOMPARE( list->count(), 0 );
+		// Cancel/reload discards unapplied edits.
+		editor.read();
+		QCOMPARE( list->count(), 1 );
+		list->item( 0 )->setSelected( true );
+		editor.findChild<QPushButton *>( "sanitizeRemove" )->click();
+		QVERIFY( editor.saveChanges() );
+		policy.load( AutoSanitizePolicy::configPath() );
+		QVERIFY( policy.rules.isEmpty() );
+	}
+
+	void dialogKeepsUnappliedChangesOnFailure()
+	{
+		QSettings().setValue( "Settings/Version", 1.0 );
+		SettingsDialog dialog;
+		dialog.show();
+		auto editor = dialog.findChild<SettingsSanitize *>();
+		QVERIFY( editor );
+		dialog.categories->setCurrentRow( dialog.content->indexOf( editor ) );
+		auto type = editor->findChild<QComboBox *>( "sanitizeBlockType" );
+		type->setCurrentText( "NiNode" );
+		editor->findChild<QPushButton *>( "sanitizeAdd" )->click();
+		QString screenshot = qEnvironmentVariable( "NIFSKOPE_TEST_SCREENSHOT" );
+		if ( !screenshot.isEmpty() ) {
+			QApplication::processEvents();
+			QVERIFY( dialog.grab().save( screenshot ) );
+		}
+		{
+			QSettings external( AutoSanitizePolicy::configPath(), QSettings::IniFormat );
+			external.setValue( "external-edit/Value", "keep" );
+		}
+		// Close the expected conflict warning; Save must leave the settings dialog open.
+		QTimer::singleShot( 0, []() {
+			if ( auto message = qobject_cast<QMessageBox *>( QApplication::activeModalWidget() ) )
+				message->accept();
+		} );
+		dialog.save();
+		QVERIFY( dialog.isVisible() );
+		QVERIFY( dialog.findChild<QDialogButtonBox *>()->button( QDialogButtonBox::Apply )->isEnabled() );
+		QCOMPARE( editor->findChild<QListWidget *>( "sanitizeExclusions" )->count(), 1 );
+		dialog.cancel();
+		AutoSanitizePolicy policy;
+		policy.load( AutoSanitizePolicy::configPath() );
+		QVERIFY( policy.rules.isEmpty() );
+	}
+};
+
+int main( int argc, char ** argv )
+{
+	QTemporaryDir config;
+	if ( !config.isValid() )
+		return 1;
+	qputenv( "XDG_CONFIG_HOME", config.path().toUtf8() );
+	QStandardPaths::setTestModeEnabled( true );
+	QApplication app( argc, argv );
+	QCoreApplication::setOrganizationName( "NifSkopeTests" );
+	QCoreApplication::setApplicationName( "AutoSanitize" );
+	QSettings::setDefaultFormat( QSettings::IniFormat );
+	QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, config.path() );
+	TestAutoSanitize test;
+	int result = QTest::qExec( &test, argc, argv );
+	QFile::remove( AutoSanitizePolicy::configPath() );
+	return result;
+}
+
+#include "tst_autosanitize.moc"


### PR DESCRIPTION
Auto-Sanitize currently applies its modifying operations without allowing users to exclude particular block types. Some assets require specific fields to remain unchanged, making otherwise useful sanitization undesirable for those blocks.

The motivating case is Starfield’s NiCamera name handling. A non-empty camera name is reported to cause a game crash. The existing name sanitizer processes NiAVObject descendants, including cameras, and can generate names when repairing duplicate empty names, invalid string indices, or names equal to BSX.

This change adds configurable exclusions for individual Auto-Sanitize operations and built-in protection for Starfield camera names.